### PR TITLE
ci: run required Helm/License checks on every PR (drop path filters)

### DIFF
--- a/.github/workflows/helm-validation.yaml
+++ b/.github/workflows/helm-validation.yaml
@@ -1,12 +1,16 @@
-# Helm Chart Validation — runs on PRs touching Helm charts
+# Helm Chart Validation — runs on every PR to main.
+#
+# Its jobs ("Discover charts", "Validate (…)") are REQUIRED status checks in the
+# protect-main ruleset. A required check must never be path-filtered: on a PR
+# that touches no matching path the workflow is skipped, the required context is
+# never reported, and the ruleset's strict policy blocks the PR forever waiting
+# for a status that will never arrive. So this runs on all PRs and stays cheap
+# (helm lint/template on a couple of small charts).
 name: Helm Validation
 
 on:
   pull_request:
-    paths:
-      - 'apps/*/deploy/helm/**'
-      - 'platform/**'
-      - 'scenarios/*/values/**'
+    branches: [main]
 
 jobs:
   discover-charts:

--- a/.github/workflows/license-scan.yml
+++ b/.github/workflows/license-scan.yml
@@ -12,13 +12,13 @@ on:
       - '**/go.mod'
       - '**/go.sum'
       - '.github/workflows/license-scan.yml'
+  # No path filter here: the "Go dependency licenses" job is a REQUIRED status
+  # check in the protect-main ruleset, and a required check must run on every PR.
+  # If it were path-filtered, a PR that touches no Go files would skip this
+  # workflow, the required context would never report, and the ruleset's strict
+  # policy would block the PR indefinitely.
   pull_request:
-    paths:
-      - 'cmd/**'
-      - 'pkg/**'
-      - '**/go.mod'
-      - '**/go.sum'
-      - '.github/workflows/license-scan.yml'
+    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
## What

Removes the `pull_request` path filters from the **Helm Validation** and **License scan** workflows so their required status-check contexts run and report on every PR to `main`.

## Why

The `protect-main` ruleset marks these jobs as **required** status checks with `strict_required_status_checks_policy` enabled:

- `Discover charts`
- `Validate (apps/go-api/deploy/helm)`
- `Validate (apps/echo-server/deploy/helm)`
- `Go dependency licenses`

Both workflows only triggered on `pull_request` when specific paths changed. A required check must never be path-filtered: on a PR that touches none of those paths, the workflow is skipped, the required context is never reported, and the strict ruleset blocks the PR **forever** waiting on a status that will never arrive.

This is exactly what stalled PR #6 (a `scenarios/**`-only change) — its 14 real checks are green, but those 4 never-reported contexts left it permanently blocked.

Related: unblocks #6.

## How it was tested

- `python3 -c "import yaml; ..."` — both workflow files parse as valid YAML.
- Verified against the live `protect-main` ruleset that these 4 contexts are the exact set required-but-missing on PR #6.
- The `push`-time path filter on `license-scan.yml` is intentionally left intact; only the `pull_request` trigger is broadened.

## Type of change

- [ ] Scenario / pack / content
- [ ] Platform module
- [ ] Docs
- [ ] Engine / CLI / SDK (requires an RFC under `docs/rfcs/` — link it)
- [x] CI / tooling

## Checklist

- [x] My commits are signed off (`git commit -s` — see DCO.md)
- [x] Conventional Commit title (`feat:`, `fix:`, `docs:`, `ci:`, `chore:`)
- [x] Cross-platform & idempotent (no GNU-only shell flags; safe to re-run)
- [ ] Updated relevant **docs** and the **runbook** (golden rule 8) — n/a, CI trigger config only
- [ ] New source files carry an SPDX header — n/a, no new source files
- [x] `go test ./...`, shellcheck, and yamllint pass locally — YAML validated; no Go/shell changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TGWSjjs79knyoqMP2KYVSQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGWSjjs79knyoqMP2KYVSQ)_