### PR TITLE
feat(metrics): optional Prometheus /metrics endpoint (#16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ labctl teardown                       # remove everything (never hangs)
 > `/etc/hosts` so the ingress hostnames below resolve; skip it and URL-based
 > access (and the `grafana-reachable` scenario check) will fail with
 > `no such host`. It is **not** needed for the labctl UI itself (a direct port).
+>
+> Want to scrape labctl itself? Start the server with `LABCTL_METRICS=true` to
+> expose an optional Prometheus endpoint at `/metrics` (off by default). See the
+> [CLI reference](docs/cli-reference.md#metrics-prometheus).
 
 [releases]: https://github.com/sagar2395/snowopslabs/releases
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -619,6 +619,32 @@ The dashboard shows:
 - Scenarios with activate/deactivate controls
 - Real-time updates via WebSocket
 
+#### Metrics (Prometheus)
+
+The server can expose an optional Prometheus `/metrics` endpoint. It is **off by
+default** and turned on with `LABCTL_METRICS=true`:
+
+```bash
+LABCTL_METRICS=true labctl ui --port 3939
+curl http://localhost:3939/metrics
+```
+
+When enabled it serves the standard text exposition format (no auth, so a local
+Prometheus can scrape it) with:
+
+| Metric | Type | Labels | Meaning |
+|--------|------|--------|---------|
+| `labctl_http_requests_total` | counter | `method`, `route`, `status` | API requests handled (route is the path template, e.g. `/api/apps/{name}/build`) |
+| `labctl_http_request_duration_seconds` | histogram | `method`, `route` | API request latency |
+| `labctl_runs_total` | counter | `kind`, `status` | Run-engine runs by kind and terminal outcome |
+| `labctl_run_duration_seconds` | histogram | `kind` | Run-engine run execution time |
+| `labctl_runs_in_flight` | gauge | — | Run-engine runs currently executing |
+| `labctl_build_info` | gauge | `version` | Always 1; carries the build version |
+
+> The `labctl_runs_*` metrics populate once operations flow through the durable
+> run engine (`internal/run`); the HTTP metrics are live for every API request.
+> The endpoint adds no scrape surface at all when `LABCTL_METRICS` is unset.
+
 ### `labctl users` — Team mode (auth & RBAC)
 
 Manage accounts for the API/UI when authentication is enabled. Authentication is

--- a/src/internal/cli/ui.go
+++ b/src/internal/cli/ui.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/sagar2395/snowopslabs/internal/httpapi"
+	"github.com/sagar2395/snowopslabs/internal/metrics"
 	"github.com/sagar2395/snowopslabs/internal/webui"
 )
 
@@ -30,7 +31,15 @@ var uiCmd = &cobra.Command{
 
 		// Use embedded UI assets (sub-directory "dist" within the embed.FS)
 		uiFS, _ := fs.Sub(webui.DistFS, "dist")
-		server := httpapi.NewServer(cfg, exec, reg, scenes, incEng, svcReg, rtm, uiFS)
+
+		// Optional Prometheus endpoint, off unless LABCTL_METRICS=true.
+		var opts []httpapi.ServerOption
+		if metrics.Enabled() {
+			opts = append(opts, httpapi.WithMetrics(metrics.NewApp(rootCmd.Version)))
+			fmt.Printf("Metrics enabled at %s/metrics\n", url)
+		}
+
+		server := httpapi.NewServer(cfg, exec, reg, scenes, incEng, svcReg, rtm, uiFS, opts...)
 		return server.Start(addr)
 	},
 }

--- a/src/internal/httpapi/metrics.go
+++ b/src/internal/httpapi/metrics.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package httpapi
+
+import (
+	"bufio"
+	"errors"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gorilla/mux"
+)
+
+// metricsMiddleware records one HTTP request metric per handled request: a
+// counter by method/route/status and a latency histogram by method/route. It
+// is only installed when the server has a metric set (WithMetrics).
+//
+// The route label is the mux path *template* (e.g. /api/apps/{name}/build), not
+// the concrete path, so cardinality stays bounded no matter how many app or
+// scenario names exist.
+func (s *Server) metricsMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The websocket stream is hijacked and long-lived; measuring it would
+		// pollute the latency histogram and complicate the hijack path, so it
+		// passes through untouched.
+		if strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+		start := time.Now()
+		next.ServeHTTP(rec, r)
+
+		route := "unmatched"
+		if cr := mux.CurrentRoute(r); cr != nil {
+			if tmpl, err := cr.GetPathTemplate(); err == nil {
+				route = tmpl
+			}
+		}
+		s.metrics.HTTPObserve(r.Method, route, rec.status, time.Since(start))
+	})
+}
+
+// statusRecorder captures the response status code while forwarding everything
+// else. It preserves the http.Hijacker and http.Flusher capabilities of the
+// underlying writer so streaming responses and websocket upgrades keep working
+// even though the websocket path bypasses this recorder.
+type statusRecorder struct {
+	http.ResponseWriter
+	status  int
+	written bool
+}
+
+func (r *statusRecorder) WriteHeader(code int) {
+	if !r.written {
+		r.status = code
+		r.written = true
+	}
+	r.ResponseWriter.WriteHeader(code)
+}
+
+func (r *statusRecorder) Write(b []byte) (int, error) {
+	// An implicit 200: a handler that writes a body without calling WriteHeader.
+	r.written = true
+	return r.ResponseWriter.Write(b)
+}
+
+func (r *statusRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if h, ok := r.ResponseWriter.(http.Hijacker); ok {
+		return h.Hijack()
+	}
+	return nil, nil, errors.New("httpapi: underlying ResponseWriter does not support hijacking")
+}
+
+func (r *statusRecorder) Flush() {
+	if f, ok := r.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}

--- a/src/internal/httpapi/metrics_test.go
+++ b/src/internal/httpapi/metrics_test.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package httpapi
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/mux"
+
+	"github.com/sagar2395/snowopslabs/internal/config"
+	"github.com/sagar2395/snowopslabs/internal/metrics"
+)
+
+func newMetricsServer(t *testing.T, opts ...ServerOption) *Server {
+	t.Helper()
+	cfg := &config.Config{ProjectRoot: t.TempDir()}
+	return NewServer(cfg, nil, nil, nil, nil, nil, nil, nil, opts...)
+}
+
+func TestMetricsEndpoint_EnabledServesExposition(t *testing.T) {
+	app := metrics.NewApp("v9.9.9")
+	s := newMetricsServer(t, WithMetrics(app))
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	s.router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /metrics = %d, want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/plain") {
+		t.Errorf("content-type = %q, want prometheus text exposition", ct)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{
+		"# TYPE labctl_http_requests_total counter",
+		"# TYPE labctl_runs_total counter",
+		`labctl_build_info{version="v9.9.9"} 1`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("exposition missing %q:\n%s", want, body)
+		}
+	}
+}
+
+func TestMetricsEndpoint_DisabledByDefault(t *testing.T) {
+	s := newMetricsServer(t) // no WithMetrics
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	s.router.ServeHTTP(rec, req)
+
+	// With metrics off, /metrics is not registered; the SPA catch-all handles
+	// it. The one thing that must never happen is a 200 exposition response.
+	if rec.Code == http.StatusOK && strings.Contains(rec.Body.String(), "labctl_") {
+		t.Errorf("/metrics must not serve metrics when disabled:\n%s", rec.Body.String())
+	}
+}
+
+func TestMetricsEndpoint_RejectsPost(t *testing.T) {
+	s := newMetricsServer(t, WithMetrics(metrics.NewApp("t")))
+	req := httptest.NewRequest(http.MethodPost, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	s.router.ServeHTTP(rec, req)
+	// mux returns 405 for a route that exists but not for this method.
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("POST /metrics = %d, want 405", rec.Code)
+	}
+}
+
+func TestMetricsMiddleware_RecordsRouteTemplate(t *testing.T) {
+	app := metrics.NewApp("test")
+	s := &Server{metrics: app}
+
+	r := mux.NewRouter()
+	api := r.PathPrefix("/api").Subrouter()
+	api.Use(s.metricsMiddleware)
+	api.HandleFunc("/apps/{name}/build", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}).Methods(http.MethodPost)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/apps/go-api/build", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("handler status = %d, want 202", rec.Code)
+	}
+
+	out := app.Render()
+	// The concrete name "go-api" must be abstracted to the {name} template so
+	// label cardinality stays bounded, and the status code is recorded.
+	want := `labctl_http_requests_total{method="POST",route="/api/apps/{name}/build",status="202"} 1`
+	if !strings.Contains(out, want) {
+		t.Errorf("expected %q in:\n%s", want, out)
+	}
+	if strings.Contains(out, "go-api") {
+		t.Errorf("concrete path value leaked into a label (unbounded cardinality):\n%s", out)
+	}
+}
+
+func TestMetricsMiddleware_ImplicitStatusAndWebsocketSkip(t *testing.T) {
+	app := metrics.NewApp("test")
+	s := &Server{metrics: app}
+
+	r := mux.NewRouter()
+	api := r.PathPrefix("/api").Subrouter()
+	api.Use(s.metricsMiddleware)
+	// Handler writes a body without calling WriteHeader -> implicit 200.
+	api.HandleFunc("/ok", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("hi"))
+	})
+	// A websocket upgrade must pass through unmeasured.
+	api.HandleFunc("/ws", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusSwitchingProtocols)
+	})
+
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/api/ok", nil))
+	wsReq := httptest.NewRequest(http.MethodGet, "/api/ws", nil)
+	wsReq.Header.Set("Upgrade", "websocket")
+	r.ServeHTTP(httptest.NewRecorder(), wsReq)
+
+	out := app.Render()
+	if !strings.Contains(out, `route="/api/ok",status="200"`) {
+		t.Errorf("implicit 200 not recorded:\n%s", out)
+	}
+	if strings.Contains(out, "/api/ws") {
+		t.Errorf("websocket request should be skipped, not measured:\n%s", out)
+	}
+}
+
+func TestStatusRecorder_Passthrough(t *testing.T) {
+	// Flush forwards to a Flusher; httptest.ResponseRecorder is one.
+	base := httptest.NewRecorder()
+	rec := &statusRecorder{ResponseWriter: base, status: http.StatusOK}
+	rec.Flush()
+	if !base.Flushed {
+		t.Error("Flush did not forward to the underlying Flusher")
+	}
+	// Hijack returns an error when the underlying writer is not a Hijacker
+	// (httptest.ResponseRecorder is not), rather than panicking.
+	if _, _, err := rec.Hijack(); err == nil {
+		t.Error("Hijack should error when the writer does not support hijacking")
+	}
+}

--- a/src/internal/httpapi/server.go
+++ b/src/internal/httpapi/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sagar2395/snowopslabs/internal/config"
 	"github.com/sagar2395/snowopslabs/internal/executor"
 	"github.com/sagar2395/snowopslabs/internal/incident"
+	"github.com/sagar2395/snowopslabs/internal/metrics"
 	"github.com/sagar2395/snowopslabs/internal/platform"
 	"github.com/sagar2395/snowopslabs/internal/runtime"
 	"github.com/sagar2395/snowopslabs/internal/scenario"
@@ -43,12 +44,26 @@ type Server struct {
 	users       *auth.Store
 	sessions    *auth.SessionStore
 	userLoadErr error
+
+	// metrics is set via WithMetrics when the /metrics endpoint is enabled;
+	// nil (the default) leaves the endpoint and request instrumentation off.
+	metrics *metrics.App
+}
+
+// ServerOption configures optional Server behaviour without changing the
+// constructor signature (existing callers pass none).
+type ServerOption func(*Server)
+
+// WithMetrics enables the Prometheus /metrics endpoint and per-request
+// instrumentation, recording into the given metric set.
+func WithMetrics(app *metrics.App) ServerOption {
+	return func(s *Server) { s.metrics = app }
 }
 
 // NewServer creates a new API server. The embeddedUI parameter should be the
 // embedded ui/dist filesystem (from go:embed). If nil or empty, the server
 // falls back to serving UI files from the project's ui/dist/ directory.
-func NewServer(cfg *config.Config, exec *executor.Executor, registry *platform.Registry, scenes *scenario.Engine, incidents *incident.Engine, svcs *services.Registry, rtm *runtime.Manager, embeddedUI fs.FS) *Server {
+func NewServer(cfg *config.Config, exec *executor.Executor, registry *platform.Registry, scenes *scenario.Engine, incidents *incident.Engine, svcs *services.Registry, rtm *runtime.Manager, embeddedUI fs.FS, opts ...ServerOption) *Server {
 	s := &Server{
 		cfg:       cfg,
 		exec:      exec,
@@ -61,6 +76,11 @@ func NewServer(cfg *config.Config, exec *executor.Executor, registry *platform.R
 			CheckOrigin: originAllowed,
 		},
 		uiFS: embeddedUI,
+	}
+	// Apply options before setupRoutes so the route table reflects them (the
+	// /metrics endpoint and request instrumentation are conditional on them).
+	for _, opt := range opts {
+		opt(s)
 	}
 	if auth.Enabled() {
 		s.authEnabled = true
@@ -110,6 +130,11 @@ func (s *Server) setupRoutes() {
 	// experience is unchanged. When on, it gates every /api route except the
 	// auth endpoints below and enforces operator-only mutations.
 	api.Use(s.authMiddleware)
+	// Request instrumentation, innermost so it measures the handler itself.
+	// Only active when metrics are enabled.
+	if s.metrics != nil {
+		api.Use(s.metricsMiddleware)
+	}
 
 	// Auth endpoints (always registered; meaningful only when auth is enabled).
 	api.HandleFunc("/auth/me", s.handleAuthMe).Methods("GET", "OPTIONS")
@@ -171,6 +196,15 @@ func (s *Server) setupRoutes() {
 	api.HandleFunc("/runtimes/{name}/deactivate", s.handleRuntimeDeactivate).Methods("POST", "OPTIONS")
 
 	api.HandleFunc("/ws", s.handleWebSocket)
+
+	// Prometheus scrape endpoint — top-level (no /api auth or JSON middleware),
+	// registered before the UI catch-all. Only present when metrics are enabled.
+	// No .Methods() restriction: the handler itself enforces GET/HEAD and
+	// answers 405 otherwise, so a POST reaches it instead of falling through to
+	// the SPA catch-all.
+	if s.metrics != nil {
+		s.router.Handle("/metrics", s.metrics.Handler())
+	}
 
 	// Serve UI — use embedded FS if available, fall back to filesystem for dev
 	var uiHandler http.Handler

--- a/src/internal/metrics/app.go
+++ b/src/internal/metrics/app.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// App is labctl's concrete metric set, built on a Registry. One App is shared
+// by the HTTP server (which records request metrics and serves the endpoint)
+// and the run engine (which records run metrics through the run.Metrics
+// interface this type satisfies).
+//
+// It deliberately knows nothing about net/http routing or the run engine's
+// types — callers pass plain strings — so neither of those packages has to
+// import a metrics library, and this package stays a leaf.
+type App struct {
+	reg *Registry
+
+	httpRequests *CounterVec   // labels: method, route, status
+	httpDuration *HistogramVec // labels: method, route
+
+	runsTotal    *CounterVec   // labels: kind, status
+	runDuration  *HistogramVec // labels: kind
+	runsInFlight *GaugeVec     // no labels
+}
+
+// NewApp builds the metric set and records the build version as a constant
+// info gauge, so /metrics is never empty even before any request or run.
+func NewApp(version string) *App {
+	r := NewRegistry()
+	a := &App{
+		reg: r,
+		httpRequests: r.NewCounterVec(
+			"labctl_http_requests_total",
+			"Total HTTP requests handled by the labctl API, by method, route template and status code.",
+			"method", "route", "status"),
+		httpDuration: r.NewHistogramVec(
+			"labctl_http_request_duration_seconds",
+			"HTTP request handling latency in seconds, by method and route template.",
+			DefaultHTTPBuckets, "method", "route"),
+		runsTotal: r.NewCounterVec(
+			"labctl_runs_total",
+			"Total run-engine runs that reached a terminal state, by kind and outcome.",
+			"kind", "status"),
+		runDuration: r.NewHistogramVec(
+			"labctl_run_duration_seconds",
+			"Run-engine run execution time in seconds, by kind.",
+			DefaultRunBuckets, "kind"),
+		runsInFlight: r.NewGaugeVec(
+			"labctl_runs_in_flight",
+			"Run-engine runs currently executing."),
+	}
+
+	buildInfo := r.NewGaugeVec(
+		"labctl_build_info",
+		"Build information; the value is always 1, the version is in the label.",
+		"version")
+	if version == "" {
+		version = "unknown"
+	}
+	buildInfo.Set(1, version)
+
+	return a
+}
+
+// Registry exposes the underlying registry (used in tests).
+func (a *App) Registry() *Registry { return a.reg }
+
+// Render returns the current metrics in Prometheus text exposition format.
+func (a *App) Render() string { return a.reg.Render() }
+
+// HTTPObserve records one handled HTTP request.
+func (a *App) HTTPObserve(method, route string, status int, dur time.Duration) {
+	code := strconv.Itoa(status)
+	a.httpRequests.Inc(method, route, code)
+	a.httpDuration.Observe(dur.Seconds(), method, route)
+}
+
+// RunStarted and RunFinished implement the run.Metrics interface, so an *App
+// can be passed straight to run.WithMetrics.
+func (a *App) RunStarted() { a.runsInFlight.Inc() }
+
+// RunFinished records a run that reached a terminal state.
+func (a *App) RunFinished(kind, status string, dur time.Duration) {
+	a.runsInFlight.Dec()
+	a.runsTotal.Inc(kind, status)
+	a.runDuration.Observe(dur.Seconds(), kind)
+}
+
+// Handler serves the exposition format. It answers GET (and HEAD) only.
+func (a *App) Handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet && r.Method != http.MethodHead {
+			w.Header().Set("Allow", "GET")
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		_, _ = w.Write([]byte(a.reg.Render()))
+	})
+}

--- a/src/internal/metrics/app_test.go
+++ b/src/internal/metrics/app_test.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestApp_BuildInfoAlwaysPresent(t *testing.T) {
+	a := NewApp("v1.2.3")
+	got := a.Render()
+	if !strings.Contains(got, `labctl_build_info{version="v1.2.3"} 1`) {
+		t.Errorf("build_info should be present with the version:\n%s", got)
+	}
+	// The metric families are pre-registered, so their TYPE lines appear even
+	// before any observation — a scraper sees the full schema.
+	for _, want := range []string{
+		"# TYPE labctl_http_requests_total counter",
+		"# TYPE labctl_http_request_duration_seconds histogram",
+		"# TYPE labctl_runs_total counter",
+		"# TYPE labctl_run_duration_seconds histogram",
+		"# TYPE labctl_runs_in_flight gauge",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing family header %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestApp_EmptyVersion(t *testing.T) {
+	if got := NewApp("").Render(); !strings.Contains(got, `version="unknown"`) {
+		t.Errorf("empty version should render as unknown:\n%s", got)
+	}
+}
+
+func TestApp_HTTPObserve(t *testing.T) {
+	a := NewApp("test")
+	a.HTTPObserve("GET", "/apps/{name}", 200, 12*time.Millisecond)
+	a.HTTPObserve("GET", "/apps/{name}", 200, 8*time.Millisecond)
+	a.HTTPObserve("POST", "/apps/{name}/build", 500, 3*time.Second)
+
+	got := a.Render()
+	for _, want := range []string{
+		`labctl_http_requests_total{method="GET",route="/apps/{name}",status="200"} 2`,
+		`labctl_http_requests_total{method="POST",route="/apps/{name}/build",status="500"} 1`,
+		`labctl_http_request_duration_seconds_count{method="GET",route="/apps/{name}"} 2`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestApp_RunMetrics(t *testing.T) {
+	a := NewApp("test")
+	// Two runs start, one finishes.
+	a.RunStarted()
+	a.RunStarted()
+	a.RunFinished("scenario.activate", "succeeded", 5*time.Second)
+
+	got := a.Render()
+	if !strings.Contains(got, "labctl_runs_in_flight 1\n") {
+		t.Errorf("in-flight should be 1 (2 started, 1 finished):\n%s", got)
+	}
+	if !strings.Contains(got, `labctl_runs_total{kind="scenario.activate",status="succeeded"} 1`) {
+		t.Errorf("runs_total not recorded:\n%s", got)
+	}
+	if !strings.Contains(got, `labctl_run_duration_seconds_count{kind="scenario.activate"} 1`) {
+		t.Errorf("run duration not observed:\n%s", got)
+	}
+}
+
+func TestApp_HandlerServesExposition(t *testing.T) {
+	a := NewApp("test")
+	a.HTTPObserve("GET", "/status", 200, time.Millisecond)
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	a.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/plain") {
+		t.Errorf("content-type = %q, want text/plain exposition", ct)
+	}
+	if !strings.Contains(rec.Body.String(), "labctl_http_requests_total") {
+		t.Errorf("body should contain metrics:\n%s", rec.Body.String())
+	}
+}
+
+func TestApp_HandlerRejectsNonGET(t *testing.T) {
+	a := NewApp("test")
+	req := httptest.NewRequest(http.MethodPost, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	a.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("POST /metrics = %d, want 405", rec.Code)
+	}
+}
+
+// The App must satisfy the run engine's Metrics interface without importing it;
+// this is a compile-time check that the method set matches.
+var _ interface {
+	RunStarted()
+	RunFinished(kind, status string, dur time.Duration)
+} = (*App)(nil)

--- a/src/internal/metrics/enabled.go
+++ b/src/internal/metrics/enabled.go
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"os"
+	"strings"
+)
+
+// Enabled reports whether the Prometheus /metrics endpoint should be served.
+// It is OFF by default and turned on with LABCTL_METRICS=true, mirroring the
+// LABCTL_AUTH gate. Keeping it opt-in means the default local experience
+// exposes no scrape surface at all.
+func Enabled() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv("LABCTL_METRICS")), "true")
+}

--- a/src/internal/metrics/registry.go
+++ b/src/internal/metrics/registry.go
@@ -1,0 +1,406 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package metrics is a tiny, dependency-free metrics registry that renders the
+// Prometheus text exposition format (version 0.0.4).
+//
+// It exists so labctl can expose an optional /metrics endpoint without pulling
+// in prometheus/client_golang and its transitive dependencies — the project is
+// deliberately cgo-free and thin on dependencies (ADR-0002). The metric set is
+// small and its label cardinality is bounded and known, so a hand-rolled
+// registry is enough; if the surface grows past what this comfortably handles,
+// swapping in client_golang behind the same call sites is a contained change.
+package metrics
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// Registry holds a set of metric families and renders them. It is safe for
+// concurrent use.
+type Registry struct {
+	mu         sync.Mutex
+	collectors []collector
+}
+
+// NewRegistry returns an empty Registry.
+func NewRegistry() *Registry { return &Registry{} }
+
+type collector interface {
+	render(sb *strings.Builder)
+}
+
+func (r *Registry) add(c collector) {
+	r.mu.Lock()
+	r.collectors = append(r.collectors, c)
+	r.mu.Unlock()
+}
+
+// Render returns the whole registry in Prometheus text exposition format.
+// Families are rendered in registration order; series within a family are
+// sorted by their label values so the output is deterministic.
+func (r *Registry) Render() string {
+	r.mu.Lock()
+	cs := make([]collector, len(r.collectors))
+	copy(cs, r.collectors)
+	r.mu.Unlock()
+
+	var sb strings.Builder
+	for _, c := range cs {
+		c.render(&sb)
+	}
+	return sb.String()
+}
+
+// ── Counter ──────────────────────────────────────────────────────────────────
+
+// CounterVec is a set of monotonically increasing counters sharing a name and
+// differing only in their label values.
+type CounterVec struct {
+	name, help string
+	labels     []string
+	mu         sync.Mutex
+	series     map[string]*counterChild
+}
+
+type counterChild struct {
+	lv  []string
+	val float64
+}
+
+// NewCounterVec registers a counter family. Panics on a malformed name or
+// duplicate label — a programming error, caught the first time it runs.
+func (r *Registry) NewCounterVec(name, help string, labels ...string) *CounterVec {
+	mustValidName(name)
+	mustValidLabels(labels)
+	c := &CounterVec{name: name, help: help, labels: labels, series: map[string]*counterChild{}}
+	r.add(c)
+	return c
+}
+
+// Inc adds one to the counter identified by labelValues (one per label, in
+// order). A mismatched arity is a programming error and panics.
+func (c *CounterVec) Inc(labelValues ...string) { c.Add(1, labelValues...) }
+
+// Add adds delta (which must be >= 0) to the identified counter.
+func (c *CounterVec) Add(delta float64, labelValues ...string) {
+	if len(labelValues) != len(c.labels) {
+		panic("metrics: counter " + c.name + ": wrong number of label values")
+	}
+	if delta < 0 {
+		panic("metrics: counter " + c.name + ": negative delta")
+	}
+	key := labelKey(labelValues)
+	c.mu.Lock()
+	child := c.series[key]
+	if child == nil {
+		child = &counterChild{lv: append([]string(nil), labelValues...)}
+		c.series[key] = child
+	}
+	child.val += delta
+	c.mu.Unlock()
+}
+
+func (c *CounterVec) render(sb *strings.Builder) {
+	c.mu.Lock()
+	children := make([]*counterChild, 0, len(c.series))
+	for _, ch := range c.series {
+		children = append(children, ch)
+	}
+	c.mu.Unlock()
+	sort.Slice(children, func(i, j int) bool { return lessLabels(children[i].lv, children[j].lv) })
+
+	writeHeader(sb, c.name, c.help, "counter")
+	for _, ch := range children {
+		writeSample(sb, c.name, c.labels, ch.lv, ch.val)
+	}
+}
+
+// ── Gauge ────────────────────────────────────────────────────────────────────
+
+// GaugeVec is a set of gauges (values that can go up or down) sharing a name.
+type GaugeVec struct {
+	name, help string
+	labels     []string
+	mu         sync.Mutex
+	series     map[string]*gaugeChild
+}
+
+type gaugeChild struct {
+	lv  []string
+	val float64
+}
+
+// NewGaugeVec registers a gauge family.
+func (r *Registry) NewGaugeVec(name, help string, labels ...string) *GaugeVec {
+	mustValidName(name)
+	mustValidLabels(labels)
+	g := &GaugeVec{name: name, help: help, labels: labels, series: map[string]*gaugeChild{}}
+	r.add(g)
+	return g
+}
+
+func (g *GaugeVec) child(labelValues []string) *gaugeChild {
+	if len(labelValues) != len(g.labels) {
+		panic("metrics: gauge " + g.name + ": wrong number of label values")
+	}
+	key := labelKey(labelValues)
+	child := g.series[key]
+	if child == nil {
+		child = &gaugeChild{lv: append([]string(nil), labelValues...)}
+		g.series[key] = child
+	}
+	return child
+}
+
+// Set replaces the value of the identified gauge.
+func (g *GaugeVec) Set(v float64, labelValues ...string) {
+	g.mu.Lock()
+	g.child(labelValues).val = v
+	g.mu.Unlock()
+}
+
+// Add adds delta (possibly negative) to the identified gauge.
+func (g *GaugeVec) Add(delta float64, labelValues ...string) {
+	g.mu.Lock()
+	g.child(labelValues).val += delta
+	g.mu.Unlock()
+}
+
+// Inc and Dec are Add(±1) on an unlabeled gauge (no label values).
+func (g *GaugeVec) Inc(labelValues ...string) { g.Add(1, labelValues...) }
+func (g *GaugeVec) Dec(labelValues ...string) { g.Add(-1, labelValues...) }
+
+func (g *GaugeVec) render(sb *strings.Builder) {
+	g.mu.Lock()
+	children := make([]*gaugeChild, 0, len(g.series))
+	for _, ch := range g.series {
+		children = append(children, ch)
+	}
+	g.mu.Unlock()
+	sort.Slice(children, func(i, j int) bool { return lessLabels(children[i].lv, children[j].lv) })
+
+	writeHeader(sb, g.name, g.help, "gauge")
+	for _, ch := range children {
+		writeSample(sb, g.name, g.labels, ch.lv, ch.val)
+	}
+}
+
+// ── Histogram ────────────────────────────────────────────────────────────────
+
+// HistogramVec is a set of histograms sharing a name and bucket layout.
+type HistogramVec struct {
+	name, help string
+	labels     []string
+	bounds     []float64 // upper bounds, ascending, no +Inf (implicit)
+	mu         sync.Mutex
+	series     map[string]*histogramChild
+}
+
+type histogramChild struct {
+	lv     []string
+	counts []uint64 // per-bucket (not cumulative); len == len(bounds)+1 (last is +Inf overflow)
+	sum    float64
+	count  uint64
+}
+
+// DefaultHTTPBuckets are latency buckets tuned for sub-second HTTP handlers.
+var DefaultHTTPBuckets = []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10}
+
+// DefaultRunBuckets span the much longer durations of cluster/scenario runs.
+var DefaultRunBuckets = []float64{0.5, 1, 5, 10, 30, 60, 120, 300, 600}
+
+// NewHistogramVec registers a histogram family. Buckets are the inclusive upper
+// bounds; they must be ascending. A +Inf bucket is always appended implicitly.
+func (r *Registry) NewHistogramVec(name, help string, buckets []float64, labels ...string) *HistogramVec {
+	mustValidName(name)
+	mustValidLabels(labels)
+	for i := 1; i < len(buckets); i++ {
+		if buckets[i] <= buckets[i-1] {
+			panic("metrics: histogram " + name + ": buckets must be strictly ascending")
+		}
+	}
+	h := &HistogramVec{
+		name: name, help: help, labels: labels,
+		bounds: append([]float64(nil), buckets...),
+		series: map[string]*histogramChild{},
+	}
+	r.add(h)
+	return h
+}
+
+// Observe records one value (seconds) in the identified histogram.
+func (h *HistogramVec) Observe(v float64, labelValues ...string) {
+	if len(labelValues) != len(h.labels) {
+		panic("metrics: histogram " + h.name + ": wrong number of label values")
+	}
+	key := labelKey(labelValues)
+	h.mu.Lock()
+	child := h.series[key]
+	if child == nil {
+		child = &histogramChild{lv: append([]string(nil), labelValues...), counts: make([]uint64, len(h.bounds)+1)}
+		h.series[key] = child
+	}
+	// First bucket whose upper bound is >= v; overflow (+Inf) is the last slot.
+	idx := sort.SearchFloat64s(h.bounds, v)
+	child.counts[idx]++
+	child.sum += v
+	child.count++
+	h.mu.Unlock()
+}
+
+func (h *HistogramVec) render(sb *strings.Builder) {
+	h.mu.Lock()
+	children := make([]*histogramChild, 0, len(h.series))
+	for _, ch := range h.series {
+		children = append(children, ch)
+	}
+	h.mu.Unlock()
+	sort.Slice(children, func(i, j int) bool { return lessLabels(children[i].lv, children[j].lv) })
+
+	writeHeader(sb, h.name, h.help, "histogram")
+	for _, ch := range children {
+		var cum uint64
+		for i, ub := range h.bounds {
+			cum += ch.counts[i]
+			writeBucket(sb, h.name, h.labels, ch.lv, formatFloat(ub), cum)
+		}
+		cum += ch.counts[len(h.bounds)] // +Inf overflow
+		writeBucket(sb, h.name, h.labels, ch.lv, "+Inf", cum)
+		writeSample(sb, h.name+"_sum", h.labels, ch.lv, ch.sum)
+		writeSampleUint(sb, h.name+"_count", h.labels, ch.lv, ch.count)
+	}
+}
+
+// ── Rendering helpers ────────────────────────────────────────────────────────
+
+func writeHeader(sb *strings.Builder, name, help, typ string) {
+	if help != "" {
+		sb.WriteString("# HELP ")
+		sb.WriteString(name)
+		sb.WriteByte(' ')
+		sb.WriteString(escapeHelp(help))
+		sb.WriteByte('\n')
+	}
+	sb.WriteString("# TYPE ")
+	sb.WriteString(name)
+	sb.WriteByte(' ')
+	sb.WriteString(typ)
+	sb.WriteByte('\n')
+}
+
+func writeSample(sb *strings.Builder, name string, labelNames, labelValues []string, v float64) {
+	sb.WriteString(name)
+	writeLabels(sb, labelNames, labelValues, "", "")
+	sb.WriteByte(' ')
+	sb.WriteString(formatFloat(v))
+	sb.WriteByte('\n')
+}
+
+func writeSampleUint(sb *strings.Builder, name string, labelNames, labelValues []string, v uint64) {
+	sb.WriteString(name)
+	writeLabels(sb, labelNames, labelValues, "", "")
+	sb.WriteByte(' ')
+	sb.WriteString(strconv.FormatUint(v, 10))
+	sb.WriteByte('\n')
+}
+
+func writeBucket(sb *strings.Builder, name string, labelNames, labelValues []string, le string, cum uint64) {
+	sb.WriteString(name)
+	sb.WriteString("_bucket")
+	writeLabels(sb, labelNames, labelValues, "le", le)
+	sb.WriteByte(' ')
+	sb.WriteString(strconv.FormatUint(cum, 10))
+	sb.WriteByte('\n')
+}
+
+// writeLabels renders {a="1",b="2"}; an extra label (extraName/extraVal) is
+// appended last, used for the histogram le="…" bucket bound.
+func writeLabels(sb *strings.Builder, names, values []string, extraName, extraVal string) {
+	if len(names) == 0 && extraName == "" {
+		return
+	}
+	sb.WriteByte('{')
+	for i, n := range names {
+		if i > 0 {
+			sb.WriteByte(',')
+		}
+		sb.WriteString(n)
+		sb.WriteString(`="`)
+		sb.WriteString(escapeLabelValue(values[i]))
+		sb.WriteByte('"')
+	}
+	if extraName != "" {
+		if len(names) > 0 {
+			sb.WriteByte(',')
+		}
+		sb.WriteString(extraName)
+		sb.WriteString(`="`)
+		sb.WriteString(escapeLabelValue(extraVal))
+		sb.WriteByte('"')
+	}
+	sb.WriteByte('}')
+}
+
+func formatFloat(v float64) string { return strconv.FormatFloat(v, 'g', -1, 64) }
+
+var labelValueEscaper = strings.NewReplacer(`\`, `\\`, "\n", `\n`, `"`, `\"`)
+var helpEscaper = strings.NewReplacer(`\`, `\\`, "\n", `\n`)
+
+func escapeLabelValue(s string) string { return labelValueEscaper.Replace(s) }
+func escapeHelp(s string) string       { return helpEscaper.Replace(s) }
+
+// labelKey joins label values into a map key that cannot collide across
+// different value tuples (a real separator byte that cannot appear mid-value
+// is unnecessary — values are joined with a NUL, which argv never contains).
+func labelKey(values []string) string { return strings.Join(values, "\x00") }
+
+func lessLabels(a, b []string) bool {
+	for i := 0; i < len(a) && i < len(b); i++ {
+		if a[i] != b[i] {
+			return a[i] < b[i]
+		}
+	}
+	return len(a) < len(b)
+}
+
+// ── Name validation (cheap guard against malformed metric definitions) ────────
+
+func mustValidName(name string) {
+	if !validIdent(name) {
+		panic("metrics: invalid metric name " + strconv.Quote(name))
+	}
+}
+
+func mustValidLabels(labels []string) {
+	seen := map[string]bool{}
+	for _, l := range labels {
+		if !validIdent(l) {
+			panic("metrics: invalid label name " + strconv.Quote(l))
+		}
+		if seen[l] {
+			panic("metrics: duplicate label name " + strconv.Quote(l))
+		}
+		seen[l] = true
+	}
+}
+
+// validIdent matches Prometheus's [a-zA-Z_][a-zA-Z0-9_]* (colons are legal in
+// metric names but reserved for recording rules, so we disallow them here).
+func validIdent(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		switch {
+		case r == '_':
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9' && i > 0:
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/src/internal/metrics/registry_test.go
+++ b/src/internal/metrics/registry_test.go
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCounterExposition(t *testing.T) {
+	r := NewRegistry()
+	c := r.NewCounterVec("reqs_total", "Total requests.", "method")
+	c.Inc("get")
+	c.Inc("get")
+	c.Add(3, "post")
+
+	got := r.Render()
+	want := "# HELP reqs_total Total requests.\n" +
+		"# TYPE reqs_total counter\n" +
+		`reqs_total{method="get"} 2` + "\n" +
+		`reqs_total{method="post"} 3` + "\n"
+	if got != want {
+		t.Errorf("counter exposition mismatch:\n got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestCounterUnlabeled(t *testing.T) {
+	r := NewRegistry()
+	c := r.NewCounterVec("events_total", "Events.")
+	c.Inc()
+	if got := r.Render(); !strings.Contains(got, "events_total 1\n") {
+		t.Errorf("unlabeled counter should render without braces:\n%s", got)
+	}
+}
+
+func TestGauge(t *testing.T) {
+	r := NewRegistry()
+	g := r.NewGaugeVec("in_flight", "In flight.")
+	g.Inc()
+	g.Inc()
+	g.Dec()
+	g.Add(5)
+	g.Set(2)
+	if got := r.Render(); !strings.Contains(got, "in_flight 2\n") || !strings.Contains(got, "# TYPE in_flight gauge\n") {
+		t.Errorf("gauge render wrong:\n%s", got)
+	}
+}
+
+func TestHistogramExposition(t *testing.T) {
+	r := NewRegistry()
+	h := r.NewHistogramVec("dur_seconds", "Durations.", []float64{0.1, 0.5, 1}, "route")
+	// 0.05 -> bucket 0.1 ; 0.2 -> bucket 0.5 ; 3 -> +Inf overflow.
+	h.Observe(0.05, "/a")
+	h.Observe(0.2, "/a")
+	h.Observe(3, "/a")
+
+	got := r.Render()
+	for _, want := range []string{
+		"# TYPE dur_seconds histogram\n",
+		`dur_seconds_bucket{route="/a",le="0.1"} 1` + "\n",  // 0.05
+		`dur_seconds_bucket{route="/a",le="0.5"} 2` + "\n",  // 0.05, 0.2 (cumulative)
+		`dur_seconds_bucket{route="/a",le="1"} 2` + "\n",    // still 2
+		`dur_seconds_bucket{route="/a",le="+Inf"} 3` + "\n", // + the 3.0
+		`dur_seconds_count{route="/a"} 3` + "\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("histogram output missing %q:\n%s", want, got)
+		}
+	}
+	// _sum is 0.05 + 0.2 + 3 = 3.25
+	if !strings.Contains(got, `dur_seconds_sum{route="/a"} 3.25`+"\n") {
+		t.Errorf("histogram _sum wrong:\n%s", got)
+	}
+}
+
+func TestHistogramBucketMonotonic(t *testing.T) {
+	r := NewRegistry()
+	h := r.NewHistogramVec("h", "h", []float64{1, 2, 3})
+	for _, v := range []float64{0.5, 1.5, 2.5, 10} {
+		h.Observe(v)
+	}
+	// Cumulative counts must be non-decreasing and end at the total.
+	var prev int
+	for _, le := range []string{"1", "2", "3", "+Inf"} {
+		line := findLine(t, r.Render(), `h_bucket{le="`+le+`"} `)
+		n := atoiTail(t, line)
+		if n < prev {
+			t.Errorf("bucket le=%s count %d < previous %d (not cumulative)", le, n, prev)
+		}
+		prev = n
+	}
+	if prev != 4 {
+		t.Errorf("+Inf bucket = %d, want total 4", prev)
+	}
+}
+
+func TestLabelValueEscaping(t *testing.T) {
+	r := NewRegistry()
+	c := r.NewCounterVec("c", "c", "path")
+	c.Inc("a\"b\\c\nd")
+	got := r.Render()
+	if !strings.Contains(got, `c{path="a\"b\\c\nd"} 1`) {
+		t.Errorf("label value not escaped correctly:\n%s", got)
+	}
+}
+
+func TestBucketBoundFormatting(t *testing.T) {
+	r := NewRegistry()
+	h := r.NewHistogramVec("h", "h", []float64{0.005, 0.025, 2.5})
+	h.Observe(0.001)
+	got := r.Render()
+	for _, le := range []string{"0.005", "0.025", "2.5"} {
+		if !strings.Contains(got, `le="`+le+`"`) {
+			t.Errorf("bucket bound %q not rendered verbatim:\n%s", le, got)
+		}
+	}
+}
+
+func TestSeriesSortedDeterministically(t *testing.T) {
+	r := NewRegistry()
+	c := r.NewCounterVec("c", "c", "k")
+	for _, v := range []string{"zeta", "alpha", "mu"} {
+		c.Inc(v)
+	}
+	got := r.Render()
+	ia := strings.Index(got, `k="alpha"`)
+	im := strings.Index(got, `k="mu"`)
+	iz := strings.Index(got, `k="zeta"`)
+	if ia >= im || im >= iz {
+		t.Errorf("series not sorted by label value:\n%s", got)
+	}
+}
+
+func TestInvalidDefinitionsPanic(t *testing.T) {
+	cases := []struct {
+		name string
+		fn   func()
+	}{
+		{"bad metric name", func() { NewRegistry().NewCounterVec("1bad", "h") }},
+		{"bad label name", func() { NewRegistry().NewCounterVec("ok", "h", "bad-label") }},
+		{"duplicate label", func() { NewRegistry().NewCounterVec("ok", "h", "a", "a") }},
+		{"non-ascending buckets", func() { NewRegistry().NewHistogramVec("ok", "h", []float64{1, 1}) }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if recover() == nil {
+					t.Errorf("expected a panic for %s", tc.name)
+				}
+			}()
+			tc.fn()
+		})
+	}
+}
+
+func TestWrongArityPanics(t *testing.T) {
+	r := NewRegistry()
+	c := r.NewCounterVec("c", "c", "a", "b")
+	defer func() {
+		if recover() == nil {
+			t.Error("expected a panic on wrong label arity")
+		}
+	}()
+	c.Inc("only-one")
+}
+
+// helpers
+
+func findLine(t *testing.T, out, prefix string) string {
+	t.Helper()
+	for _, l := range strings.Split(out, "\n") {
+		if strings.HasPrefix(l, prefix) {
+			return l
+		}
+	}
+	t.Fatalf("no line with prefix %q in:\n%s", prefix, out)
+	return ""
+}
+
+func atoiTail(t *testing.T, line string) int {
+	t.Helper()
+	fields := strings.Fields(line)
+	n := 0
+	for _, r := range fields[len(fields)-1] {
+		n = n*10 + int(r-'0')
+	}
+	return n
+}

--- a/src/internal/run/engine.go
+++ b/src/internal/run/engine.go
@@ -141,12 +141,31 @@ type Engine struct {
 
 	subs *subscribers
 
+	// metrics, when non-nil, receives run-lifecycle signals.
+	metrics Metrics
+
 	wg       sync.WaitGroup
 	shutdown chan struct{}
 }
 
+// Metrics receives run-lifecycle signals for observability. It is deliberately
+// tiny and framework-free so the engine does not depend on any metrics library;
+// internal/metrics.App satisfies it. A nil Metrics (the default) disables it.
+type Metrics interface {
+	// RunStarted is called once a run transitions to running.
+	RunStarted()
+	// RunFinished is called once a run reaches a terminal state, with its kind,
+	// terminal status ("succeeded", "failed", …) and wall-clock duration.
+	RunFinished(kind, status string, dur time.Duration)
+}
+
 // Option configures an Engine.
 type Option func(*Engine)
+
+// WithMetrics attaches a metrics sink that receives run-lifecycle signals.
+func WithMetrics(m Metrics) Option {
+	return func(e *Engine) { e.metrics = m }
+}
 
 // WithWorkers sets how many non-conflicting runs execute concurrently.
 func WithWorkers(n int) Option {

--- a/src/internal/run/metrics_test.go
+++ b/src/internal/run/metrics_test.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package run
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sagar2395/snowopslabs/internal/store"
+)
+
+// fakeMetrics is a thread-safe run.Metrics that records what it was told.
+type fakeMetrics struct {
+	mu       sync.Mutex
+	started  int
+	finished []finishedRun
+}
+
+type finishedRun struct {
+	kind, status string
+	dur          time.Duration
+}
+
+func (m *fakeMetrics) RunStarted() {
+	m.mu.Lock()
+	m.started++
+	m.mu.Unlock()
+}
+
+func (m *fakeMetrics) RunFinished(kind, status string, dur time.Duration) {
+	m.mu.Lock()
+	m.finished = append(m.finished, finishedRun{kind, status, dur})
+	m.mu.Unlock()
+}
+
+func (m *fakeMetrics) snapshot() (int, []finishedRun) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.started, append([]finishedRun(nil), m.finished...)
+}
+
+// waitForFinished polls until the sink has recorded n terminal runs. RunFinished
+// fires just after the store records the terminal status, so a test that has
+// only waited on the store status must give this a moment to land.
+func (m *fakeMetrics) waitForFinished(t *testing.T, n int) []finishedRun {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, fin := m.snapshot(); len(fin) >= n {
+			return fin
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	_, fin := m.snapshot()
+	t.Fatalf("metrics recorded %d finished runs, want %d", len(fin), n)
+	return nil
+}
+
+func TestEngineMetrics_RecordsLifecycle(t *testing.T) {
+	ctx := context.Background()
+	m := &fakeMetrics{}
+	h := newHarness(t, WithMetrics(m))
+
+	// A run that succeeds.
+	okID, err := h.engine.Submit(ctx, Spec{Kind: "scenario.activate", Script: h.script("ok.sh")})
+	if err != nil {
+		t.Fatalf("Submit ok: %v", err)
+	}
+	h.waitForStatus(okID, store.StatusSucceeded)
+
+	// A run that fails (its script exits non-zero).
+	failScript := h.script("fail.sh")
+	h.fake.WhenArgsContain("fail.sh", "", 1)
+	failID, err := h.engine.Submit(ctx, Spec{Kind: "platform.install", Script: failScript})
+	if err != nil {
+		t.Fatalf("Submit fail: %v", err)
+	}
+	h.waitForStatus(failID, store.StatusFailed)
+
+	fin := m.waitForFinished(t, 2)
+
+	started, _ := m.snapshot()
+	if started != 2 {
+		t.Errorf("RunStarted called %d times, want 2", started)
+	}
+	// In-flight must balance: every start has a matching finish.
+	if len(fin) != started {
+		t.Errorf("started %d != finished %d (in-flight would not return to zero)", started, len(fin))
+	}
+
+	byKind := map[string]finishedRun{}
+	for _, f := range fin {
+		byKind[f.kind] = f
+	}
+	if got := byKind["scenario.activate"]; got.status != "succeeded" {
+		t.Errorf("scenario.activate status = %q, want succeeded", got.status)
+	}
+	if got := byKind["platform.install"]; got.status != "failed" {
+		t.Errorf("platform.install status = %q, want failed", got.status)
+	}
+}
+
+func TestEngineMetrics_NilIsNoop(t *testing.T) {
+	// The default engine (no WithMetrics) must run fine with a nil sink.
+	ctx := context.Background()
+	h := newHarness(t)
+	id, err := h.engine.Submit(ctx, Spec{Kind: "lab.up", Script: h.script("ok.sh")})
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	h.waitForStatus(id, store.StatusSucceeded)
+}

--- a/src/internal/run/worker.go
+++ b/src/internal/run/worker.go
@@ -84,6 +84,9 @@ func (e *Engine) execute(id string) {
 		return
 	}
 	e.subs.publish(Event{Type: EventStatus, RunID: id, Status: store.StatusRunning})
+	if e.metrics != nil {
+		e.metrics.RunStarted()
+	}
 
 	sink := newLogSink(ctx, e.store, e.subs, id, e.now)
 
@@ -91,7 +94,7 @@ func (e *Engine) execute(id string) {
 	if err != nil {
 		sink.system("cannot run " + rec.Script + ": " + err.Error())
 		sink.flush()
-		e.finish(ctx, id, store.StatusFailed, nil, err.Error(), 0)
+		e.finish(ctx, id, rec.Kind, store.StatusFailed, nil, err.Error(), 0)
 		return
 	}
 
@@ -137,7 +140,7 @@ func (e *Engine) execute(id string) {
 	_ = e.store.FinishSteps(ctx, id, stepStatus, e.now())
 
 	sink.close()
-	e.finish(ctx, id, status, exitCode, message, elapsed)
+	e.finish(ctx, id, rec.Kind, status, exitCode, message, elapsed)
 }
 
 // classify turns an execution outcome into a terminal status, an exit code and
@@ -167,11 +170,14 @@ func classify(runCtx, timeoutCtx context.Context, timeout time.Duration, res too
 	return store.StatusFailed, nil, runErr.Error()
 }
 
-func (e *Engine) finish(ctx context.Context, id string, status store.Status, exitCode *int, message string, elapsed time.Duration) {
+func (e *Engine) finish(ctx context.Context, id, kind string, status store.Status, exitCode *int, message string, elapsed time.Duration) {
 	// Ignore the error: a nil return means another path already recorded a
 	// terminal state, which is the correct outcome for a race.
 	_ = e.store.FinishRun(ctx, id, status, exitCode, message, e.now(), elapsed)
 	e.subs.publish(Event{Type: EventStatus, RunID: id, Status: status})
+	if e.metrics != nil {
+		e.metrics.RunFinished(kind, string(status), elapsed)
+	}
 }
 
 func intPtr(i int) *int { return &i }


### PR DESCRIPTION
## What

Adds an **opt-in** Prometheus `/metrics` endpoint to the labctl API/UI server. Off by default; enabled with `LABCTL_METRICS=true` (mirrors the existing `LABCTL_AUTH` gate). When unset, the server exposes no scrape surface at all.

## Why

Closes #16. Gives operators run-engine and HTTP observability without bolting on a monitoring stack, and does it dependency-free so the module stays cgo-free and thin (ADR-0002) — a small `internal/metrics` registry renders the Prometheus text exposition format instead of pulling in `prometheus/client_golang`.

Metrics exposed:
- `labctl_http_requests_total{method,route,status}` + `labctl_http_request_duration_seconds{method,route}` — recorded by a server middleware. The `route` label is the mux path **template** (e.g. `/api/apps/{name}/build`), so cardinality stays bounded; the websocket stream is skipped.
- `labctl_runs_total{kind,status}`, `labctl_run_duration_seconds{kind}`, `labctl_runs_in_flight` — fed by a new `run.WithMetrics` hook (a tiny `run.Metrics` interface the engine calls on start/finish; `nil` is a no-op). These light up once operations flow through the durable run engine (`internal/run`); the HTTP metrics are live for every API request today.
- `labctl_build_info{version}` so `/metrics` is never empty.

`NewServer` gains a **variadic `ServerOption`** — every existing caller/test compiles unchanged — and `labctl ui` passes `WithMetrics` only when the gate is on.

## How it was tested

No cluster required — the feature is hermetically testable:
- `go test -race ./internal/metrics/ ./internal/httpapi/ ./internal/run/` — exposition-format correctness (cumulative buckets, label escaping, deterministic ordering, validation panics), engine lifecycle recording (in-flight balances, kind/status), and the endpoint enabled/disabled + route-template labelling via `httptest`.
- `make test-go` — full race suite + coverage gate pass (metrics 95%, run 87%).
- `golangci-lint` clean; end-to-end against the built binary:
  ```
  LABCTL_METRICS=true labctl ui --port 3939 & curl -s localhost:3939/metrics   # serves exposition; API hits increment counters
  labctl ui --port 3940 & curl -s -o /dev/null -w '%{http_code}' localhost:3940/metrics   # 404 when disabled
  ```

## Type of change

- [ ] Scenario / pack / content
- [ ] Platform module
- [ ] Docs
- [x] Engine / CLI / SDK — the design is specified in issue #16 (owner-authored); no separate RFC was filed
- [ ] CI / tooling

## Checklist

- [x] My commits are signed off (`git commit -s` — see DCO.md)
- [x] Conventional Commit title (`feat:`)
- [x] Cross-platform & idempotent (pure Go, no shell; endpoint safe to scrape repeatedly)
- [x] Updated relevant **docs** (`docs/cli-reference.md` metrics table + README note)
- [x] New source files carry an SPDX header
- [x] `go test ./...` and `golangci-lint` pass locally