### PR TITLE
feat(doctor): warn when the Docker VM has < 4 CPU / 8 GB (#4)

### DIFF
--- a/src/internal/cli/doctor.go
+++ b/src/internal/cli/doctor.go
@@ -3,14 +3,28 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
+	"strconv"
+	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/sagar2395/snowopslabs/internal/toolchain"
+)
+
+// The most common first-run failure is an under-provisioned Docker VM: `make
+// init` stands up a 3-node k3d cluster plus the full platform stack, which OOMs
+// or times out (a cryptic API-server "TLS handshake timeout") on a default
+// 2 GB VM. doctor catches it before the build does. Thresholds mirror the
+// README guidance.
+const (
+	minDockerCPU      = 4
+	minDockerMemBytes = 8 << 30 // 8 GiB
 )
 
 // doctorCmd tells the user what is wrong with their environment *before* they
@@ -77,10 +91,15 @@ func runDoctor(ctx context.Context, out io.Writer, runner toolchain.Runner) erro
 		problems = append(problems, r)
 	}
 
-	if len(warnings) > 0 {
+	dockerNote := dockerResourceWarning(ctx, runner)
+
+	if len(warnings) > 0 || dockerNote != "" {
 		fmt.Fprintln(out, "\nNotes:")
 		for _, r := range warnings {
 			fmt.Fprintf(out, "  - %s\n", r.Detail)
+		}
+		if dockerNote != "" {
+			fmt.Fprintf(out, "  - %s\n", dockerNote)
 		}
 	}
 
@@ -120,6 +139,86 @@ func statusLabel(r toolchain.CheckResult) string {
 	default:
 		return "unknown"
 	}
+}
+
+// dockerResourceWarning returns an actionable, multi-line warning when the
+// Docker/container engine has fewer than the minimum CPUs or memory SnowOps
+// Labs needs, or "" when resources are sufficient or cannot be determined.
+//
+// It degrades gracefully, exactly like the missing-tool checks: if docker is
+// not on PATH, the daemon is unreachable, or `docker info` output cannot be
+// parsed, it stays silent rather than guessing — a missing docker is already
+// reported by the preflight table, and a stopped daemon is a different problem.
+func dockerResourceWarning(ctx context.Context, runner toolchain.Runner) string {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	ncpu, mem, ok := dockerResources(ctx, runner)
+	if !ok {
+		return ""
+	}
+	if ncpu >= minDockerCPU && mem >= minDockerMemBytes {
+		return ""
+	}
+
+	const gib = 1 << 30
+	// A whole number when the VM is set to an integer GiB (the common case),
+	// one decimal otherwise, so "2 GiB" doesn't render as "2.0 GiB".
+	detectedMem := strconv.FormatFloat(float64(mem)/gib, 'f', -1, 64)
+
+	return fmt.Sprintf(
+		"⚠️  Docker has %d CPU / %s GiB available; SnowOps Labs needs at least %d CPU / %d GiB.\n"+
+			"    A 3-node k3d cluster plus the platform stack (Prometheus, Grafana, Loki, …)\n"+
+			"    OOM-kills pods or fails with an API-server \"TLS handshake timeout\" below this.\n"+
+			"    Colima:         colima stop && colima start --cpu %d --memory %d\n"+
+			"    Docker Desktop: Settings → Resources → raise CPUs to %d and Memory to %d GB",
+		ncpu, detectedMem, minDockerCPU, minDockerMemBytes/gib,
+		minDockerCPU, minDockerMemBytes/gib, minDockerCPU, minDockerMemBytes/gib,
+	)
+}
+
+// dockerResources reports the CPU count and total memory (bytes) the Docker
+// engine has, via `docker info`. ok is false when the value cannot be
+// determined (docker absent, daemon down, or unparseable output).
+func dockerResources(ctx context.Context, runner toolchain.Runner) (ncpu int, memBytes int64, ok bool) {
+	path, err := runner.LookPath("docker")
+	if err != nil {
+		return 0, 0, false
+	}
+
+	// Bound the call: a wedged daemon should not hang `doctor`.
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	var buf bytes.Buffer
+	// --format keeps this machine-readable and locale-independent; NCPU and
+	// MemTotal (bytes) are the simplest source of truth (docker info fields).
+	_, err = runner.Run(ctx, toolchain.Command{
+		Path:   path,
+		Args:   []string{"info", "--format", "{{.NCPU}} {{.MemTotal}}"},
+		Stdout: &buf,
+	})
+	if err != nil {
+		return 0, 0, false
+	}
+
+	fields := strings.Fields(buf.String())
+	if len(fields) != 2 {
+		return 0, 0, false
+	}
+	ncpu, err = strconv.Atoi(fields[0])
+	if err != nil {
+		return 0, 0, false
+	}
+	memBytes, err = strconv.ParseInt(fields[1], 10, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+	if ncpu <= 0 || memBytes <= 0 {
+		return 0, 0, false
+	}
+	return ncpu, memBytes, true
 }
 
 func init() {

--- a/src/internal/cli/doctor_test.go
+++ b/src/internal/cli/doctor_test.go
@@ -12,26 +12,38 @@ import (
 	"github.com/sagar2395/snowopslabs/internal/toolchain"
 )
 
+// fakeEnv builds a Fake where every required tool resolves and reports a
+// current version. dockerInfo is the scripted "{{.NCPU}} {{.MemTotal}}" output
+// of `docker info` (e.g. "2 2147483648" for 2 CPU / 2 GiB); its rule is added
+// first so `docker info` matches it, not the generic `docker` version rule.
+func fakeEnv(dockerInfo string) *toolchain.Fake {
+	f := toolchain.NewFake()
+	f.Available = map[string]string{
+		"bash": "/bin/bash", "kubectl": "/usr/bin/kubectl", "helm": "/usr/bin/helm",
+		"docker": "/usr/bin/docker", "k3d": "/usr/bin/k3d", "kind": "/usr/bin/kind",
+	}
+	f.WhenArgsContain("info", dockerInfo+"\n", 0)
+	f.WhenArgsContain("/bin/bash", "GNU bash, version 5.2.21(1)-release\n", 0)
+	f.WhenArgsContain("kubectl", `{"clientVersion":{"gitVersion":"v1.31.0"}}`+"\n", 0)
+	f.WhenArgsContain("helm", "v3.16.0\n", 0)
+	f.WhenArgsContain("docker", "27.0.0\n", 0)
+	f.WhenArgsContain("k3d", "k3d version v5.8.3\n", 0)
+	f.WhenArgsContain("kind", "kind v0.27.0\n", 0)
+	return f
+}
+
 // doctor's whole value is the quality of its output, so these assert on what
 // the user reads, not just the exit status.
 
 func TestRunDoctor(t *testing.T) {
 	ctx := context.Background()
 
-	// A fake where every tool resolves and reports a current version.
+	// A fake where every tool resolves and reports a current version, and the
+	// Docker VM is comfortably provisioned. The `docker info` rule is registered
+	// first so `docker info` matches it rather than the generic `docker` version
+	// rule (first match wins).
 	healthy := func() *toolchain.Fake {
-		f := toolchain.NewFake()
-		f.Available = map[string]string{
-			"bash": "/bin/bash", "kubectl": "/usr/bin/kubectl", "helm": "/usr/bin/helm",
-			"docker": "/usr/bin/docker", "k3d": "/usr/bin/k3d", "kind": "/usr/bin/kind",
-		}
-		f.WhenArgsContain("/bin/bash", "GNU bash, version 5.2.21(1)-release\n", 0)
-		f.WhenArgsContain("kubectl", `{"clientVersion":{"gitVersion":"v1.31.0"}}`+"\n", 0)
-		f.WhenArgsContain("helm", "v3.16.0\n", 0)
-		f.WhenArgsContain("docker", "27.0.0\n", 0)
-		f.WhenArgsContain("k3d", "k3d version v5.8.3\n", 0)
-		f.WhenArgsContain("kind", "kind v0.27.0\n", 0)
-		return f
+		return fakeEnv("16 17179869184") // 16 CPU, 16 GiB — well above the minimum
 	}
 
 	t.Run("a healthy environment succeeds", func(t *testing.T) {
@@ -160,6 +172,116 @@ func TestRunDoctor(t *testing.T) {
 		if err := runDoctor(nil, &out, healthy()); err != nil {
 			t.Fatalf("runDoctor: %v", err)
 		}
+	})
+
+	t.Run("warns (but does not fail) when the Docker VM is under-provisioned", func(t *testing.T) {
+		var out bytes.Buffer
+		// 2 CPU / 2 GiB — the classic default Docker Desktop / Colima VM.
+		if err := runDoctor(ctx, &out, fakeEnv("2 2147483648")); err != nil {
+			t.Fatalf("an under-provisioned VM is a warning, not a failure: %v\n%s", err, out.String())
+		}
+		text := out.String()
+		if strings.Contains(text, "Problems to fix") {
+			t.Errorf("resources are a note, not a blocking problem:\n%s", text)
+		}
+		// Name the shortfall and both fixes (README guidance).
+		for _, want := range []string{
+			"Notes:", "Docker has 2 CPU / 2 GiB", "needs at least 4 CPU / 8 GiB",
+			"colima start --cpu 4 --memory 8", "Docker Desktop",
+		} {
+			if !strings.Contains(text, want) {
+				t.Errorf("output should mention %q:\n%s", want, text)
+			}
+		}
+	})
+
+	t.Run("no resource warning when the Docker VM is sufficient", func(t *testing.T) {
+		var out bytes.Buffer
+		if err := runDoctor(ctx, &out, fakeEnv("4 8589934592")); err != nil { // exactly 4 CPU / 8 GiB
+			t.Fatalf("runDoctor: %v", err)
+		}
+		if strings.Contains(out.String(), "needs at least") {
+			t.Errorf("a VM meeting the minimum should not warn:\n%s", out.String())
+		}
+	})
+
+	t.Run("no resource warning when the Docker daemon is unreachable", func(t *testing.T) {
+		f := healthy()
+		// `docker info` fails (daemon down) — a different problem, silently skipped.
+		f2 := toolchain.NewFake()
+		f2.Available = f.Available
+		f2.WhenArgsContain("info", "", 1)
+		f2.WhenArgsContain("/bin/bash", "GNU bash, version 5.2.21(1)-release\n", 0)
+		f2.WhenArgsContain("kubectl", `{"clientVersion":{"gitVersion":"v1.31.0"}}`+"\n", 0)
+		f2.WhenArgsContain("helm", "v3.16.0\n", 0)
+		f2.WhenArgsContain("docker", "27.0.0\n", 0)
+		f2.WhenArgsContain("k3d", "k3d version v5.8.3\n", 0)
+		f2.WhenArgsContain("kind", "kind v0.27.0\n", 0)
+
+		var out bytes.Buffer
+		if err := runDoctor(ctx, &out, f2); err != nil {
+			t.Fatalf("runDoctor: %v", err)
+		}
+		if strings.Contains(out.String(), "needs at least") {
+			t.Errorf("a stopped daemon should not produce a resource warning:\n%s", out.String())
+		}
+	})
+}
+
+func TestDockerResourceWarning(t *testing.T) {
+	ctx := context.Background()
+
+	newFake := func(dockerInfo string, exit int) *toolchain.Fake {
+		f := toolchain.NewFake()
+		f.Available = map[string]string{"docker": "/usr/bin/docker"}
+		f.WhenArgsContain("info", dockerInfo, exit)
+		return f
+	}
+
+	t.Run("warns below the CPU minimum", func(t *testing.T) {
+		if got := dockerResourceWarning(ctx, newFake("2 17179869184", 0)); !strings.Contains(got, "2 CPU") {
+			t.Errorf("expected a CPU warning, got %q", got)
+		}
+	})
+
+	t.Run("warns below the memory minimum", func(t *testing.T) {
+		got := dockerResourceWarning(ctx, newFake("8 2147483648", 0))
+		if !strings.Contains(got, "8 CPU / 2 GiB") {
+			t.Errorf("expected a memory warning naming the detected values, got %q", got)
+		}
+	})
+
+	t.Run("silent exactly at the minimum", func(t *testing.T) {
+		if got := dockerResourceWarning(ctx, newFake("4 8589934592", 0)); got != "" {
+			t.Errorf("4 CPU / 8 GiB meets the minimum; want no warning, got %q", got)
+		}
+	})
+
+	t.Run("silent when docker is not installed", func(t *testing.T) {
+		f := toolchain.NewFake()
+		f.Available = map[string]string{} // docker absent -> LookPath fails
+		if got := dockerResourceWarning(ctx, f); got != "" {
+			t.Errorf("missing docker is reported elsewhere; want no warning, got %q", got)
+		}
+	})
+
+	t.Run("silent when the daemon is unreachable", func(t *testing.T) {
+		if got := dockerResourceWarning(ctx, newFake("", 1)); got != "" {
+			t.Errorf("a stopped daemon should be skipped, got %q", got)
+		}
+	})
+
+	t.Run("silent on unparseable output", func(t *testing.T) {
+		for _, bad := range []string{"lots of ram", "8", "0 0", "-1 8589934592"} {
+			if got := dockerResourceWarning(ctx, newFake(bad, 0)); got != "" {
+				t.Errorf("output %q is unparseable; want no warning, got %q", bad, got)
+			}
+		}
+	})
+
+	t.Run("nil context does not panic", func(t *testing.T) {
+		//nolint:staticcheck // deliberately passing nil to prove it is handled
+		_ = dockerResourceWarning(nil, newFake("16 17179869184", 0))
 	})
 }
 


### PR DESCRIPTION
## What

`labctl doctor` now warns when the Docker/container engine has fewer than **4 CPUs or 8 GiB** of memory, naming the exact fix — before `make init` fails partway through with a cryptic error.

## Why

Closes #4. The most common first-run failure is an under-provisioned Docker/Colima VM: `make init` stands up a 3-node k3d cluster plus the full platform stack, which OOM-kills pods or dies with an API-server `TLS handshake timeout` on a default 2 GB VM — with no hint that memory is the cause. `doctor` should catch it *before* the build does.

It inspects the engine via `docker info --format '{{.NCPU}} {{.MemTotal}}'` and prints an actionable note (both the Colima and Docker Desktop fixes, plus the detected values). It is a **note, not a blocking failure** (the VM still works, just slowly), and degrades gracefully — silent when docker is absent (already reported by the preflight table), the daemon is unreachable, or the output can't be parsed. The `docker info` call is bounded by a 5s timeout so a wedged daemon can't hang `doctor`.

## How it was tested

No cluster required:
- `go test ./internal/cli/ -run 'Doctor|DockerResource'` — covers under-provisioned (CPU and memory), the exact-minimum boundary, sufficient resources, missing docker, stopped daemon, unparseable output, and a nil context.
- `go build ./...` and the doctor tests pass on top of latest `main`.
- Verified against the built binary: with no Docker daemon reachable, `doctor` degrades gracefully (no resource line, no crash).

## Type of change

- [ ] Scenario / pack / content
- [ ] Platform module
- [ ] Docs
- [x] Engine / CLI / SDK — the design is specified in issue #4 (owner-authored, labelled *good first issue*); no separate RFC was filed
- [ ] CI / tooling

## Checklist

- [x] My commits are signed off (`git commit -s` — see DCO.md)
- [x] Conventional Commit title (`feat:`)
- [x] Cross-platform & idempotent (pure Go, no GNU-only flags; uses the Docker API values, not platform-specific shelling)
- [x] Updated relevant docs (the ≥4 CPU / 8 GB guidance already lives in the README; this surfaces it in `doctor`)
- [x] New source files carry an SPDX header (no new files; edits keep the existing header)
- [x] `go test ./...` passes locally

---
_Generated by [Claude Code](https://claude.ai/code/session_018K2cEQiRHFSyQeZC2Ms7k4)_