### PR TITLE
Autoscaling audit remediation + platform/observability/reset UX fixes

### DIFF
--- a/.github/workflows/e2e-kind.yaml
+++ b/.github/workflows/e2e-kind.yaml
@@ -55,7 +55,10 @@ jobs:
           kind load docker-image go-api:latest --name "$CLUSTER_NAME"
 
       - name: Activate scenario
-        run: labctl scenario up env-promotion
+        # env-promotion lists go-api as a prerequisite app; --deploy-prereqs
+        # builds and deploys it (the image is already loaded into kind above)
+        # before activating, so the run doesn't fail preflight.
+        run: labctl scenario up env-promotion --deploy-prereqs
 
       - name: Verify scenario checks pass
         run: labctl scenario verify env-promotion

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,5 @@
 ifneq (,$(wildcard .env))
 	include .env
-	# .env values keep any whitespace between the value and an inline
-	# "# comment": Make strips the comment text but not the spaces before it, so
-	# `PROFILE=k3d   # ...` becomes "k3d   ". Left as-is, that whitespace flows
-	# into recipes (bash runtimes/k3d   /up.sh) and into the exported environment
-	# the Go tools read, breaking cluster names, ports and profile lookups.
 	# Normalise every variable the file defines with $(strip). This keeps any
 	# existing .env working, including ones copied from an older, inline-commented
 	# .env.example.
@@ -23,10 +18,6 @@ COVERAGE_MIN ?= 80
 # Defaults are read from .env if present; any command may override them by
 # passing VAR=val on the make command line.
 
-# Orchestration and repo-wide gates run from the content root. The Go/UI build
-# and test targets live in the self-contained module under src/ (src/Makefile)
-# and are delegated in below, so `make cli-build`, `make test`, etc. still work
-# from here.
 include make/vars.mk
 include make/bootstrap.mk
 include make/runtime.mk
@@ -36,11 +27,6 @@ include make/check.mk
 include make/services.mk
 include make/shell.mk
 
-# Targets implemented by the src/ module. Running any of them here delegates to
-# `make -C src <target>` so the build executes where go.mod lives. BIN_DIR is
-# passed as an absolute path to the repo-root bin/ so the host binary lands at
-# ./bin/labctl (gitignored) rather than src/bin/labctl — the module still
-# defaults to src/bin when built standalone. Only the cli-* targets read it.
 SRC_TARGETS := cli-build cli-build-all cli-install cli-clean ui-build ui-deps \
                test-go test-api test-coverage coverage-check fuzz \
                lint-go lint-ui sec vuln golden-update validate-content \
@@ -80,16 +66,9 @@ run:
 	@$(MAKE) local-run APP_NAME=$(APP_NAME)
 
 ## ui: rebuild the UI + binary (fresh embed) and launch the web UI
-# One command so "rebuild and see new code" can't skip the UI build or run a
-# stale binary. It runs in the foreground; the server refuses to start if another
-# labctl ui already holds the port.
 ui: cli-build
 	@./bin/labctl ui
 
-## ui-dev: launch the web UI serving the UI live from src/ui/dist on disk
-# No Go rebuild to see UI changes: edit the UI, run `make -C src ui-build`
-# (or `cd src/ui && npm run build`), then refresh the browser. Needs bin/labctl
-# to exist once (build it with `make cli-build`).
 .PHONY: ui ui-dev
 ui-dev:
 	@LABCTL_UI_DIR=$(CURDIR)/src/ui/dist ./bin/labctl ui

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,21 @@ reset: teardown init
 run:
 	@$(MAKE) local-run APP_NAME=$(APP_NAME)
 
+## ui: rebuild the UI + binary (fresh embed) and launch the web UI
+# One command so "rebuild and see new code" can't skip the UI build or run a
+# stale binary. It runs in the foreground; the server refuses to start if another
+# labctl ui already holds the port.
+ui: cli-build
+	@./bin/labctl ui
+
+## ui-dev: launch the web UI serving the UI live from src/ui/dist on disk
+# No Go rebuild to see UI changes: edit the UI, run `make -C src ui-build`
+# (or `cd src/ui && npm run build`), then refresh the browser. Needs bin/labctl
+# to exist once (build it with `make cli-build`).
+.PHONY: ui ui-dev
+ui-dev:
+	@LABCTL_UI_DIR=$(CURDIR)/src/ui/dist ./bin/labctl ui
+
 # ── Help ─────────────────────────────────────────────────────────────────────
 
 help:
@@ -86,6 +101,8 @@ help:
 	@echo ""
 	@echo "  Quick start:"
 	@echo "    make cli-build           Build bin/labctl (UI embedded)"
+	@echo "    make ui                  Rebuild UI + binary and launch the web UI"
+	@echo "    make ui-dev              Launch the web UI serving src/ui/dist live (no Go rebuild)"
 	@echo "    make init                setup-tools + runtime-up + platform-up"
 	@echo "    make teardown            Remove apps, platform and cluster"
 	@echo "    make reset               teardown then init"

--- a/apps/echo-server/app.env
+++ b/apps/echo-server/app.env
@@ -1,6 +1,5 @@
 # Application-specific configuration for echo-server
 # Sourced by engine/build.sh and engine/deploy.sh to discover strategies.
-# Variables prefixed with * are required; others can be customized or left commented.
 
 # === Identity (Required) ===
 APP_NAME=echo-server                # Must match parent directory name
@@ -20,25 +19,3 @@ HELM_VALUES=values-dev.yaml         # Values file: values-dev.yaml, values-prod-
 # DOCKERFILE=Dockerfile             # Dockerfile path (defaults to apps/echo-server/Dockerfile)
 # DOCKER_REGISTRY=myregistry        # Registry for push (if deploying to cloud)
 # DOCKER_IMAGE_TAG=latest           # Image tag (defaults to 'latest')
-
-# === Resource Configuration (Optional: override helm values) ===
-# MEMORY_REQUEST=128Mi
-# MEMORY_LIMIT=512Mi
-# CPU_REQUEST=50m
-# CPU_LIMIT=500m
-
-# === Replicas & Scaling ===
-# These are NOT configured via app.env (the build/deploy engine does not read
-# any replica or HPA setting here). Set the static replica count in the Helm
-# values file (deploy/helm/values-*.yaml). Autoscaling is demonstrated by the
-# `autoscaling-under-load` scenario (a KEDA ScaledObject with tunable
-# min/max replicas and RPS threshold).
-
-# === Application Runtime (Optional: reference only; actual values injected via Helm) ===
-# These are NOT read by the build/deploy engine. They document env vars the
-# container expects. Set real values in deploy/helm/values-*.yaml under 'env:'.
-# LOG_LEVEL=info
-# METRICS_ENABLED=true
-# CACHE_TTL=1h
-# Leave unset to run without Redis; set this only after Redis is installed.
-# REDIS_URL=redis://redis-master.services.svc.cluster.local:6379

--- a/apps/echo-server/app.env
+++ b/apps/echo-server/app.env
@@ -27,11 +27,12 @@ HELM_VALUES=values-dev.yaml         # Values file: values-dev.yaml, values-prod-
 # CPU_REQUEST=50m
 # CPU_LIMIT=500m
 
-# === Replica & Scaling (Optional) ===
-# REPLICAS=1
-# AUTOSCALE=false
-# HPA_MIN=1
-# HPA_MAX=10
+# === Replicas & Scaling ===
+# These are NOT configured via app.env (the build/deploy engine does not read
+# any replica or HPA setting here). Set the static replica count in the Helm
+# values file (deploy/helm/values-*.yaml). Autoscaling is demonstrated by the
+# `autoscaling-under-load` scenario (a KEDA ScaledObject with tunable
+# min/max replicas and RPS threshold).
 
 # === Application Runtime (Optional: reference only; actual values injected via Helm) ===
 # These are NOT read by the build/deploy engine. They document env vars the

--- a/apps/go-api/app.env
+++ b/apps/go-api/app.env
@@ -20,24 +20,3 @@ HELM_VALUES=values-dev.yaml        # Values file: values-dev.yaml, values-prod-l
 # DOCKERFILE=Dockerfile            # Dockerfile path (defaults to apps/go-api/Dockerfile)
 # DOCKER_REGISTRY=myregistry       # Registry for push (if deploying to cloud)
 # DOCKER_IMAGE_TAG=latest          # Image tag (defaults to 'latest')
-
-# === Resource Configuration (Optional: override helm values) ===
-# MEMORY_REQUEST=128Mi
-# MEMORY_LIMIT=512Mi
-# CPU_REQUEST=50m
-# CPU_LIMIT=500m
-
-# === Replicas & Scaling ===
-# These are NOT configured via app.env (the build/deploy engine does not read
-# any replica or HPA setting here). Set the static replica count in the Helm
-# values file (deploy/helm/values-*.yaml). Autoscaling is demonstrated by the
-# `autoscaling-under-load` scenario, which installs a KEDA ScaledObject and
-# exposes its min/max replicas and RPS threshold as tunable parameters:
-#   labctl scenario up autoscaling-under-load --set Threshold=15 --set MaxReplicas=4
-
-# === Application Runtime (Optional: reference only; actual values injected via Helm) ===
-# These are NOT read by the build/deploy engine. They document env vars the
-# container expects. Set real values in deploy/helm/values-*.yaml under 'env:'.
-# LOG_LEVEL=info
-# METRICS_ENABLED=true
-# SHUTDOWN_TIMEOUT=10s

--- a/apps/go-api/app.env
+++ b/apps/go-api/app.env
@@ -27,11 +27,13 @@ HELM_VALUES=values-dev.yaml        # Values file: values-dev.yaml, values-prod-l
 # CPU_REQUEST=50m
 # CPU_LIMIT=500m
 
-# === Replica & Scaling (Optional) ===
-# REPLICAS=1
-# AUTOSCALE=false
-# HPA_MIN=1
-# HPA_MAX=10
+# === Replicas & Scaling ===
+# These are NOT configured via app.env (the build/deploy engine does not read
+# any replica or HPA setting here). Set the static replica count in the Helm
+# values file (deploy/helm/values-*.yaml). Autoscaling is demonstrated by the
+# `autoscaling-under-load` scenario, which installs a KEDA ScaledObject and
+# exposes its min/max replicas and RPS threshold as tunable parameters:
+#   labctl scenario up autoscaling-under-load --set Threshold=15 --set MaxReplicas=4
 
 # === Application Runtime (Optional: reference only; actual values injected via Helm) ===
 # These are NOT read by the build/deploy engine. They document env vars the

--- a/apps/go-api/deploy/helm/templates/servicemonitor.yaml
+++ b/apps/go-api/deploy/helm/templates/servicemonitor.yaml
@@ -3,9 +3,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "go-api.fullname" . }}
-  # Live in the app's own namespace so the endpoint selector matches its Service.
-  # The kube-prometheus-stack watches ServiceMonitors in all namespaces
-  # (serviceMonitorNamespaceSelector: {}), so it is still discovered here.
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "go-api.labels" . | nindent 4 }}

--- a/apps/go-api/deploy/helm/templates/servicemonitor.yaml
+++ b/apps/go-api/deploy/helm/templates/servicemonitor.yaml
@@ -3,9 +3,14 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "go-api.fullname" . }}
-  namespace: {{ .Values.serviceMonitor.namespace }}
+  # Live in the app's own namespace so the endpoint selector matches its Service.
+  # The kube-prometheus-stack watches ServiceMonitors in all namespaces
+  # (serviceMonitorNamespaceSelector: {}), so it is still discovered here.
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "go-api.labels" . | nindent 4 }}
+    # Required: the stack only selects ServiceMonitors carrying this release label.
+    release: {{ .Values.serviceMonitor.releaseLabel }}
 spec:
   selector:
     matchLabels:

--- a/apps/go-api/deploy/helm/values.yaml
+++ b/apps/go-api/deploy/helm/values.yaml
@@ -131,10 +131,17 @@ prometheus:
   port: 8080
   path: /metrics
 
-# ServiceMonitor for Prometheus Operator
+# ServiceMonitor for the Prometheus Operator.
+# Off by default: this app is already scraped through the platform's annotation
+# based "kubernetes-pods" job (it carries prometheus.io/scrape: "true"), so
+# enabling this too would double-scrape /metrics and double every rate. Turn it
+# on only if you also remove the pod's prometheus.io/scrape annotation and want
+# the explicit ServiceMonitor path instead.
+# releaseLabel must match the stack's serviceMonitorSelector (it selects
+# ServiceMonitors labelled release=<its release name>, default "prometheus").
 serviceMonitor:
   enabled: false
-  namespace: monitoring
+  releaseLabel: prometheus
   interval: 30s
   scrapeTimeout: 10s
 

--- a/apps/go-api/deploy/helm/values.yaml
+++ b/apps/go-api/deploy/helm/values.yaml
@@ -1,12 +1,7 @@
 # Default values for go-api Helm chart
 
-# Override the name of the chart
 nameOverride: ""
-
-# Override the full name of the release
 fullnameOverride: ""
-
-# Global settings
 global:
   environment: k3d
 

--- a/platform/chaos/chaos-mesh/install.sh
+++ b/platform/chaos/chaos-mesh/install.sh
@@ -4,11 +4,6 @@ set -euo pipefail
 NAMESPACE="chaos-mesh"
 SCRIPT_DIR="$(dirname "$0")"
 
-# Select the containerd socket path based on the active runtime profile.
-# Each container runtime / cloud provider places the socket at a different path:
-#   k3d  → /run/k3s/containerd/containerd.sock  (k3s embeds its own containerd)
-#   aks  → /run/containerd/containerd.sock       (standard containerd on Azure nodes)
-#   eks  → /run/containerd/containerd.sock       (standard containerd on Bottlerocket/AL2 nodes)
 case "${PROFILE:-k3d}" in
   k3d) CONTAINERD_SOCKET="/run/k3s/containerd/containerd.sock" ;;
   aks | eks) CONTAINERD_SOCKET="/run/containerd/containerd.sock" ;;
@@ -26,8 +21,6 @@ helm repo add chaos-mesh https://charts.chaos-mesh.org >/dev/null 2>&1 || true
 helm repo update
 
 # Install or upgrade Chaos Mesh with the runtime-appropriate socket path.
-# The socketPath is NOT in values.yaml (which would be k3d-only) — it is passed
-# here via --set so cloud runtimes work without any values.yaml changes.
 echo "Installing Chaos Mesh chart..."
 helm upgrade --install chaos-mesh chaos-mesh/chaos-mesh \
   --namespace $NAMESPACE \
@@ -44,10 +37,7 @@ kubectl rollout status deployment/chaos-controller-manager -n $NAMESPACE --timeo
 echo "Waiting for Chaos Mesh dashboard to be ready..."
 kubectl rollout status deployment/chaos-dashboard -n $NAMESPACE --timeout=120s || true
 
-# Expose the dashboard through Traefik at a stable URL so it works without a
-# manual port-forward (securityMode is off, so no login token is needed). The
-# host uses DOMAIN_SUFFIX from the executor env; add it to /etc/hosts with
-# `labctl hosts sync` (the "chaos" subdomain is managed there).
+# Expose the dashboard through Traefik at a stable URL.
 DOMAIN_SUFFIX="${DOMAIN_SUFFIX:-k3d.local}"
 echo "Exposing Chaos Mesh dashboard at http://chaos.${DOMAIN_SUFFIX} ..."
 kubectl apply -f - <<EOF

--- a/platform/chaos/chaos-mesh/install.sh
+++ b/platform/chaos/chaos-mesh/install.sh
@@ -44,12 +44,39 @@ kubectl rollout status deployment/chaos-controller-manager -n $NAMESPACE --timeo
 echo "Waiting for Chaos Mesh dashboard to be ready..."
 kubectl rollout status deployment/chaos-dashboard -n $NAMESPACE --timeout=120s || true
 
+# Expose the dashboard through Traefik at a stable URL so it works without a
+# manual port-forward (securityMode is off, so no login token is needed). The
+# host uses DOMAIN_SUFFIX from the executor env; add it to /etc/hosts with
+# `labctl hosts sync` (the "chaos" subdomain is managed there).
+DOMAIN_SUFFIX="${DOMAIN_SUFFIX:-k3d.local}"
+echo "Exposing Chaos Mesh dashboard at http://chaos.${DOMAIN_SUFFIX} ..."
+kubectl apply -f - <<EOF
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: chaos-dashboard
+  namespace: $NAMESPACE
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: chaos.${DOMAIN_SUFFIX}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: chaos-dashboard
+                port:
+                  number: 2333
+EOF
+
 echo ""
 echo "Chaos Mesh installed successfully"
 echo "Namespace: $NAMESPACE"
 echo "Status: kubectl get pods -n $NAMESPACE"
 echo ""
-echo "Dashboard: kubectl port-forward -n $NAMESPACE svc/chaos-dashboard 2333:2333"
-echo "  Then open http://localhost:2333"
+echo "Dashboard: http://chaos.${DOMAIN_SUFFIX}  (run 'labctl hosts sync' once if the host doesn't resolve)"
+echo "  Or port-forward: kubectl port-forward -n $NAMESPACE svc/chaos-dashboard 2333:2333  → http://localhost:2333"
 echo ""
 echo "Create experiments via CRDs or the Chaos Dashboard UI."

--- a/platform/monitoring/grafana/provisioning/dashboards/app-requests.json
+++ b/platform/monitoring/grafana/provisioning/dashboards/app-requests.json
@@ -20,7 +20,10 @@
   "links": [],
   "panels": [
     {
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -97,7 +100,10 @@
       "type": "timeseries"
     },
     {
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -163,14 +169,14 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, rate(http_request_duration_seconds_bucket[5m])) by (job)",
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le, job))",
           "format": "time_series",
           "hide": false,
           "legendFormat": "p95 - {{ job }}",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.99, rate(http_request_duration_seconds_bucket[5m])) by (job)",
+          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket[5m])) by (le, job))",
           "format": "time_series",
           "hide": false,
           "legendFormat": "p99 - {{ job }}",
@@ -181,7 +187,10 @@
       "type": "timeseries"
     },
     {
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -247,10 +256,10 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(http_requests_total{job=\"go-api\"}[5m])) by (status)",
+          "expr": "sum(rate(http_requests_total{job=\"go-api\"}[5m])) by (code)",
           "format": "time_series",
           "hide": false,
-          "legendFormat": "Status {{ status }}",
+          "legendFormat": "Status {{ code }}",
           "refId": "A"
         }
       ],
@@ -258,7 +267,10 @@
       "type": "timeseries"
     },
     {
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -328,7 +340,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(http_requests_total{status=~\"5..\"}[5m])) by (job)",
+          "expr": "sum(rate(http_requests_total{code=~\"5..\"}[5m])) by (job)",
           "format": "time_series",
           "hide": false,
           "legendFormat": "5xx Errors - {{ job }}",

--- a/platform/monitoring/grafana/provisioning/dashboards/cluster-metrics.json
+++ b/platform/monitoring/grafana/provisioning/dashboards/cluster-metrics.json
@@ -20,7 +20,10 @@
   "links": [],
   "panels": [
     {
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -97,7 +100,10 @@
       "type": "timeseries"
     },
     {
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -174,7 +180,10 @@
       "type": "timeseries"
     },
     {
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -221,7 +230,10 @@
       "type": "piechart"
     },
     {
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/platform/monitoring/grafana/provisioning/dashboards/pod-resources.json
+++ b/platform/monitoring/grafana/provisioning/dashboards/pod-resources.json
@@ -20,7 +20,10 @@
   "links": [],
   "panels": [
     {
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -97,7 +100,10 @@
       "type": "timeseries"
     },
     {
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -174,7 +180,10 @@
       "type": "timeseries"
     },
     {
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -221,7 +230,10 @@
       "type": "piechart"
     },
     {
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/platform/monitoring/grafana/values.yaml
+++ b/platform/monitoring/grafana/values.yaml
@@ -39,16 +39,23 @@ datasources:
   datasources.yaml:
     apiVersion: 1
     datasources:
+      # Stable uids (not Grafana's random per-install ones) so dashboards and
+      # Explore deep links can reference a datasource by a known id. Dashboard
+      # JSON targets uid "prometheus"; the app "Logs"/"Traces" links target
+      # "loki"/"tempo".
       - name: Prometheus
+        uid: prometheus
         type: prometheus
         url: http://prometheus-kube-prometheus-prometheus.monitoring.svc.cluster.local:9090
         isDefault: true
         editable: true
       - name: Loki
+        uid: loki
         type: loki
         url: http://loki-gateway.monitoring.svc.cluster.local
         editable: true
       - name: Tempo
+        uid: tempo
         type: tempo
         url: http://tempo.monitoring.svc.cluster.local:3100
         editable: true

--- a/platform/monitoring/grafana/values.yaml
+++ b/platform/monitoring/grafana/values.yaml
@@ -26,11 +26,6 @@ persistence:
     - ReadWriteOnce
   size: 5Gi
 
-# The default init-chown-data container runs `chown` over the whole data volume
-# on every (re)start. On k3d's local-path (hostPath-backed) PVC that chown hits
-# "Permission denied" and crash-loops, blocking Grafana from ever starting on an
-# upgrade/reinstall. local-path already mounts the volume with correct
-# ownership, so this init step is unnecessary here — disable it.
 initChownData:
   enabled: false
 
@@ -39,10 +34,6 @@ datasources:
   datasources.yaml:
     apiVersion: 1
     datasources:
-      # Stable uids (not Grafana's random per-install ones) so dashboards and
-      # Explore deep links can reference a datasource by a known id. Dashboard
-      # JSON targets uid "prometheus"; the app "Logs"/"Traces" links target
-      # "loki"/"tempo".
       - name: Prometheus
         uid: prometheus
         type: prometheus
@@ -72,23 +63,12 @@ dashboardProviders:
         disableDeletion: false
         editable: true
         options:
-          # The grafana chart mounts each entry of dashboardsConfigMaps at
-          # /var/lib/grafana/dashboards/<provider>, so the provider path must
-          # point at that subfolder (not the parent) for the JSON to load.
           path: /var/lib/grafana/dashboards/default
 
-# Mount our curated dashboard JSON (packaged as the grafana-dashboards ConfigMap
-# by install.sh) under the 'default' provider path above. Without this the
-# provider directory is empty and Grafana shows no dashboards / "no data".
 dashboardsConfigMaps:
   default: grafana-dashboards
 
-# The dashboard sidecar watches for ConfigMaps labelled grafana_dashboard="1"
-# and loads them live — this is how scenarios (e.g. observability-sre's SLO
-# dashboards) ship dashboards into a running Grafana without a chart upgrade.
-# Without it those scenario ConfigMaps are created but never rendered, so the
-# panels silently never appear. searchNamespace: ALL so dashboards created in
-# any namespace (not just monitoring) are picked up.
+# The dashboard sidecar watches for ConfigMaps labelled grafana_dashboard="1" and loads them live.
 sidecar:
   dashboards:
     enabled: true
@@ -101,14 +81,6 @@ sidecar:
 
 # Dashboard downloads disabled - dashboards ship as local JSON via the ConfigMap.
 dashboards: {}
-# dashboards:
-#   default:
-#     cluster-metrics:
-#       url: https://raw.githubusercontent.com/prometheus-community/grafana-dashboards/main/kubernetes-cluster/dashboard.json
-#       token: ''
-#     pod-resources:
-#       url: https://raw.githubusercontent.com/prometheus-community/grafana-dashboards/main/kubernetes-cluster-monitoring/pods.json
-#       token: ''
 
 # Grafana plugins
 plugins: []

--- a/scenarios/autoscaling-under-load/manifests/scaledobject.yaml
+++ b/scenarios/autoscaling-under-load/manifests/scaledobject.yaml
@@ -2,6 +2,11 @@
 # The Prometheus server address reads the monitoring namespace from the engine
 # template ({{.MonitoringNamespace}}) — no hardcoded namespace (rule 3/4).
 #
+# min/maxReplicaCount and the RPS threshold are scenario PARAMETERS: they default
+# to 1 / 6 / 25 but can be overridden at activation to experiment with how the
+# autoscaler behaves — `labctl scenario up autoscaling-under-load --set Threshold=15`
+# or the Activate dialog in the UI. See scenario.yaml's `parameters:` block.
+#
 # Threshold is RPS-per-replica: desiredReplicas = ceil(totalRPS / threshold),
 # clamped to [minReplicaCount, maxReplicaCount]. With the spike profile holding
 # ~100 RPS and threshold 25, go-api scales to ~4 replicas; at the 10 RPS
@@ -14,8 +19,8 @@ metadata:
 spec:
   scaleTargetRef:
     name: go-api
-  minReplicaCount: 1
-  maxReplicaCount: 6
+  minReplicaCount: {{.MinReplicas}}
+  maxReplicaCount: {{.MaxReplicas}}
   pollingInterval: 15      # seconds between metric polls
   cooldownPeriod: 60       # seconds at/under threshold before scaling down
   advanced:
@@ -29,6 +34,5 @@ spec:
     - type: prometheus
       metadata:
         serverAddress: "http://prometheus-kube-prometheus-prometheus.{{.MonitoringNamespace}}.svc:9090"
-        metricName: go_api_requests_per_second
-        query: "sum(rate(http_requests_total{app=\"go-api\"}[1m]))"
-        threshold: "25"
+        query: "sum(rate(http_requests_total{app=\"go-api\"}[1m]))"  # total RPS across pods
+        threshold: "{{.Threshold}}"                                  # RPS per replica

--- a/scenarios/autoscaling-under-load/manifests/scaledobject.yaml
+++ b/scenarios/autoscaling-under-load/manifests/scaledobject.yaml
@@ -2,11 +2,6 @@
 # The Prometheus server address reads the monitoring namespace from the engine
 # template ({{.MonitoringNamespace}}) — no hardcoded namespace (rule 3/4).
 #
-# min/maxReplicaCount and the RPS threshold are scenario PARAMETERS: they default
-# to 1 / 6 / 25 but can be overridden at activation to experiment with how the
-# autoscaler behaves — `labctl scenario up autoscaling-under-load --set Threshold=15`
-# or the Activate dialog in the UI. See scenario.yaml's `parameters:` block.
-#
 # Threshold is RPS-per-replica: desiredReplicas = ceil(totalRPS / threshold),
 # clamped to [minReplicaCount, maxReplicaCount]. With the spike profile holding
 # ~100 RPS and threshold 25, go-api scales to ~4 replicas; at the 10 RPS

--- a/scenarios/autoscaling-under-load/scenario.yaml
+++ b/scenarios/autoscaling-under-load/scenario.yaml
@@ -21,6 +21,34 @@ objectives:
   - "Drive a traffic spike and watch replicas scale up on Prometheus RPS"
   - "Confirm latency stays within SLO while scaled, then scales back on cooldown"
 
+# Tunable knobs for experimentation — override at activation with
+# `labctl scenario up autoscaling-under-load --set Threshold=15 --set MaxReplicas=4`
+# or via the Activate dialog in the UI. Each is substituted into
+# manifests/scaledobject.yaml as a {{.Name}} template variable.
+parameters:
+  - name: MinReplicas
+    displayName: "Minimum replicas"
+    description: "Floor the autoscaler never scales below (idle baseline). The scenario story starts at 1."
+    default: "1"
+    type: int
+    min: 1
+    max: 10
+    notGreaterThan: MaxReplicas
+  - name: MaxReplicas
+    displayName: "Maximum replicas"
+    description: "Ceiling the autoscaler will not exceed no matter how high the load — try lowering it to watch the workload saturate at the cap."
+    default: "6"
+    type: int
+    min: 1
+    max: 10
+  - name: Threshold
+    displayName: "RPS per replica (scale threshold)"
+    description: "Target request rate per replica. Lower = scales more aggressively (more replicas for the same load); higher = more conservative."
+    default: "25"
+    type: int
+    min: 1
+    max: 500
+
 stages:
   - name: autoscaler
     description: Declare the ScaledObject and the replicas-vs-RPS dashboard
@@ -83,7 +111,7 @@ references:
 
 snippets:
   - label: "KEDA ScaledObject for go-api (the autoscaler this scenario installs)"
-    description: "Scales go-api 1→6 on Prometheus RPS. Edit the threshold and re-apply to change how aggressively it scales."
+    description: "The autoscaler this scenario installs. It scales go-api on its Prometheus request rate: desiredReplicas = ceil(total RPS ÷ threshold), clamped between minReplicaCount and maxReplicaCount. The defaults scale 1→6 at 25 RPS per replica — override the parameters at activation to change how aggressively it reacts."
     path: manifests/scaledobject.yaml
   - label: "Inspect the HPA KEDA created"
     description: "Not a manifest to apply — a quick way to watch the desired/current replica maths live."
@@ -94,7 +122,7 @@ snippets:
 explore:
   urls:
     - label: "Grafana — Autoscaling dashboard (replicas vs RPS)"
-      url: "http://grafana.{{.DomainSuffix}}"
+      url: "http://grafana.{{.DomainSuffix}}/d/autoscaling-under-load"
     - label: "Prometheus"
       url: "http://prometheus.{{.DomainSuffix}}"
   commands:

--- a/scenarios/autoscaling-under-load/scenario.yaml
+++ b/scenarios/autoscaling-under-load/scenario.yaml
@@ -23,8 +23,6 @@ objectives:
 
 # Tunable knobs for experimentation — override at activation with
 # `labctl scenario up autoscaling-under-load --set Threshold=15 --set MaxReplicas=4`
-# or via the Activate dialog in the UI. Each is substituted into
-# manifests/scaledobject.yaml as a {{.Name}} template variable.
 parameters:
   - name: MinReplicas
     displayName: "Minimum replicas"
@@ -63,9 +61,6 @@ stages:
         path: dashboards/
         namespace: "{{.MonitoringNamespace}}"
 
-# These checks assert the POST-SPIKE state (run the spike profile first — see the
-# explore commands). At baseline go-api sits at 1 replica; under the spike KEDA
-# scales it up, and `scenario verify` confirms it.
 checks:
   - name: keda-operator-ready
     type: kubectl

--- a/scenarios/backup-restore-drill/scenario.yaml
+++ b/scenarios/backup-restore-drill/scenario.yaml
@@ -55,6 +55,11 @@ checks:
     type: script
     script: scripts/check-backup-exists.sh
 
+snippets:
+  - label: "The restore canary this drill backs up"
+    description: "A ConfigMap in the go-api namespace acting as the canary: the drill backs it up, deletes it, then restores it. If its value survives the round-trip, the restore worked."
+    path: manifests/baseline.yaml
+
 explore:
   commands:
     - label: "1. Back up the go-api namespace to a manifest archive"

--- a/scenarios/chaos-engineering/scenario.yaml
+++ b/scenarios/chaos-engineering/scenario.yaml
@@ -56,14 +56,22 @@ checks:
     url: "http://go-api.{{.DomainSuffix}}/health"
     expectStatus: 200
 
+snippets:
+  - label: "Chaos Mesh experiments (pod-kill, pod-failure, network partition, CPU stress)"
+    description: "Four failure injections targeting go-api by label. Apply one at a time with a label selector (e.g. -l experiment=pod-kill) and watch how the platform reacts."
+    path: manifests/chaos-experiments.yaml
+  - label: "PodDisruptionBudget protecting go-api during chaos"
+    description: "Caps how many go-api pods can be down at once, so voluntary disruptions can't take the service fully offline."
+    path: manifests/pod-disruption-budgets.yaml
+
 explore:
   urls:
-    - label: "Grafana Chaos Dashboard"
-      url: "http://grafana.{{.DomainSuffix}}"
+    - label: "Grafana — go-api requests (watch RPS/errors during chaos)"
+      url: "http://grafana.{{.DomainSuffix}}/d/app-requests"
     - label: "Chaos Mesh Dashboard"
-      url: "http://localhost:2333 (run port-forward first)"
+      url: "http://chaos.{{.DomainSuffix}}"
   commands:
-    - label: "Port-forward Chaos Mesh dashboard"
+    - label: "Port-forward Chaos Mesh dashboard (fallback if the URL doesn't resolve)"
       command: "kubectl port-forward -n chaos-mesh svc/chaos-dashboard 2333:2333 &"
     - label: "List all active experiments"
       command: "kubectl get podchaos,networkchaos,stresschaos --all-namespaces"
@@ -79,6 +87,7 @@ explore:
       command: "kubectl get pdb -n go-api"
   tips:
     - "Start by generating background traffic, then activate experiments to see their impact in Grafana"
+    - "Grafana → the linked go-api requests dashboard: during an experiment watch RPS dip and 5xx errors rise, then recover as pods self-heal. A healthy platform returns to baseline within seconds."
     - "Pod kill experiments test self-healing — Kubernetes will restart terminated pods automatically"
     - "Network delay experiments simulate degraded connectivity — watch latency spike in Grafana"
     - "CPU stress triggers HPA scale-up if autoscaling is enabled — watch replica count increase"

--- a/scenarios/chaos-engineering/scenario.yaml
+++ b/scenarios/chaos-engineering/scenario.yaml
@@ -8,6 +8,7 @@ prerequisites:
     - ingress
     - monitoring/metrics
     - monitoring/grafana
+    - chaos/chaos-mesh
   apps:
     - go-api
 runtimes:

--- a/scenarios/cluster-upgrade-drill/scenario.yaml
+++ b/scenarios/cluster-upgrade-drill/scenario.yaml
@@ -50,10 +50,15 @@ checks:
     operator: ">="
     value: "0.99"
 
+snippets:
+  - label: "PodDisruptionBudget that keeps go-api up across the node roll"
+    description: "maxUnavailable: 1 forces the rolling upgrade to wait for a Ready replacement before evicting the next pod — the mechanism that keeps availability up while worker nodes are replaced one at a time."
+    path: manifests/baseline.yaml
+
 explore:
   urls:
     - label: "Grafana — go-api availability"
-      url: "http://grafana.{{.DomainSuffix}}"
+      url: "http://grafana.{{.DomainSuffix}}/d/app-requests"
   commands:
     - label: "1. Start steady background traffic (keep running in another terminal)"
       command: "labctl traffic start --profile steady --rps 20"
@@ -67,6 +72,7 @@ explore:
       command: "kubectl get nodes -o custom-columns=NAME:.metadata.name,VERSION:.status.nodeInfo.kubeletVersion"
   tips:
     - "Start traffic FIRST — the availability check reads http_requests_total from Prometheus over a 10m window covering the upgrade."
+    - "Grafana → the linked availability dashboard: the request-success line should stay near 100% across the whole node roll — expect only brief dips as each node cycles out and back in."
     - "HONEST SCOPE: k3d cannot upgrade a node in place. upgrade.sh deletes each agent node and recreates it on the target k3s image — a faithful simulation of a rolling WORKER upgrade. The server/control-plane node is left as-is; on a managed cluster (EKS/AKS) the provider upgrades the control plane first, then the nodes."
     - "The PDB (maxUnavailable: 1) makes each node's drain block until go-api has a Ready replica elsewhere — that is what keeps the success rate up."
     - "Roll one node at a time. Recreating all agents at once would briefly leave nowhere to run go-api and tank availability — that is the anti-pattern this drill teaches against."

--- a/scenarios/cost-right-sizing/scenario.yaml
+++ b/scenarios/cost-right-sizing/scenario.yaml
@@ -62,12 +62,17 @@ checks:
     operator: ">="
     value: "1"
 
+snippets:
+  - label: "The over-provisioned 'before' state (40× CPU, 32× memory)"
+    description: "go-api's deliberately inflated resource requests. This is the waste OpenCost surfaces — right-size these requests, re-deploy, and verify the cost drops."
+    path: values/overprovisioned.yaml
+
 explore:
   urls:
     - label: "OpenCost UI — per-namespace cost breakdown"
       url: "http://localhost:9090 (port-forward first — see commands below)"
     - label: "Grafana — go-api resource usage vs requests"
-      url: "http://grafana.{{.DomainSuffix}}"
+      url: "http://grafana.{{.DomainSuffix}}/d/pod-resources"
   commands:
     - label: "0. Open the OpenCost UI (run in background)"
       command: "kubectl -n opencost port-forward svc/opencost 9090 &"
@@ -84,6 +89,7 @@ explore:
     - label: "Inspect the current CPU request"
       command: "kubectl -n go-api get deploy go-api -o jsonpath='{.spec.template.spec.containers[0].resources}'"
   tips:
+    - "Grafana → the linked Pod Resources dashboard: compare the flat 'requests' line against the much lower 'usage' line — that gap is the waste. After right-sizing, requests should drop toward actual usage."
     - "OpenCost uses on-prem pricing defaults in k3d (~$0.048/CPU-hr, ~$0.006/GB-hr). Numbers are relative — useful for comparing before vs after, not real invoices."
     - "Requests drive Kubernetes scheduling and cloud node billing. Limits cap container usage but don't affect node cost. Right-sizing requests is where the savings are."
     - "2000m CPU request = 2 vCPUs reserved per pod even at idle. At ~$0.048/vCPU-hr that's ~$2.30/pod/day before any actual load — for a go-api serving <1 RPS."

--- a/scenarios/env-promotion/scenario.yaml
+++ b/scenarios/env-promotion/scenario.yaml
@@ -93,6 +93,11 @@ checks:
     resource: configmap/env-metadata
     namespace: env-prod
 
+snippets:
+  - label: "The dev environment (namespace, deployment, service, ingress)"
+    description: "One environment's full stack in its own namespace, tagged with the image version. Staging and prod are the same shape — promotion carries the image tag forward from one to the next."
+    path: manifests/dev-env.yaml
+
 explore:
   urls:
     - label: "go-api — dev environment"

--- a/scenarios/event-driven-arch/scenario.yaml
+++ b/scenarios/event-driven-arch/scenario.yaml
@@ -73,6 +73,14 @@ checks:
     operator: ">="
     value: "1"
 
+snippets:
+  - label: "The 'orders' Kafka topic (3 partitions)"
+    description: "A Strimzi KafkaTopic. Three partitions let the consumer group scale to three parallel consumers."
+    path: manifests/topic.yaml
+  - label: "Producer + consumer group on the orders topic"
+    description: "A continuous producer (one order every ~0.5s) and a consumer in the 'order-processors' group, built from Kafka's console tools — no custom app needed."
+    path: manifests/producer-consumer.yaml
+
 explore:
   urls:
     - label: "Grafana (Strimzi / Kafka dashboards if imported)"

--- a/scenarios/gitops-cicd/scenario.yaml
+++ b/scenarios/gitops-cicd/scenario.yaml
@@ -6,6 +6,7 @@ category: delivery
 prerequisites:
   platform:
     - ingress
+    - gitops/argocd
   apps: []
 runtimes:
   - k3d
@@ -50,6 +51,11 @@ checks:
     type: kubectl
     resource: application/echo-server
     namespace: argocd
+
+snippets:
+  - label: "ArgoCD Application CRDs for go-api and echo-server"
+    description: "The declarative GitOps contract: ArgoCD watches each app's Helm path in Git and keeps the cluster in sync. automated.prune + selfHeal mean drift is corrected automatically."
+    path: manifests/argocd-applications.yaml
 
 explore:
   urls:

--- a/scenarios/mesh-traffic-management/scenario.yaml
+++ b/scenarios/mesh-traffic-management/scenario.yaml
@@ -95,8 +95,8 @@ snippets:
 
 explore:
   urls:
-    - label: "Grafana (mesh / app dashboards)"
-      url: "http://grafana.{{.DomainSuffix}}"
+    - label: "Grafana — go-api requests (v1/v2 traffic split)"
+      url: "http://grafana.{{.DomainSuffix}}/d/app-requests"
   commands:
     - label: "Send 20 requests and watch the 90/10 split by version"
       command: "for i in $(seq 1 20); do kubectl -n go-api exec deploy/go-api-v1 -c go-api -- wget -qO- http://go-api-canary/version 2>/dev/null; done | sort | uniq -c"
@@ -108,6 +108,7 @@ explore:
       command: "kubectl -n go-api get virtualservice go-api-canary -o jsonpath='{.spec.http[0].route}{\"\\n\"}'"
   tips:
     - "Subsets v1/v2 are selected by the pod label 'version'; the DestinationRule maps them."
+    - "Grafana → the linked go-api requests dashboard: with the 90/10 split v2 should carry ~10% of requests. Shift the VirtualService weights, re-apply, and watch the balance move."
     - "Shift the split by editing spec.http[0].route weights and re-applying — canary promotion."
     - "The fault-injection stage adds a fixed delay to the v2 subset; mesh-level, no app change."
     - "STRICT mTLS means plaintext clients without a sidecar are rejected — that is the security win."

--- a/scenarios/node-drain-drill/scenario.yaml
+++ b/scenarios/node-drain-drill/scenario.yaml
@@ -59,10 +59,15 @@ checks:
     type: script
     script: scripts/check-no-cordon.sh
 
+snippets:
+  - label: "PodDisruptionBudget that makes the drain non-disruptive"
+    description: "maxUnavailable: 1 means evicting one go-api pod blocks until a replacement is Ready on another node — the core mechanism that keeps the service up while a node is drained."
+    path: manifests/baseline.yaml
+
 explore:
   urls:
     - label: "Grafana — go-api availability"
-      url: "http://grafana.{{.DomainSuffix}}"
+      url: "http://grafana.{{.DomainSuffix}}/d/app-requests"
   commands:
     - label: "1. Start steady background traffic (keep running in another terminal)"
       command: "labctl traffic start --profile steady --rps 20"
@@ -78,6 +83,7 @@ explore:
       command: "kubectl -n go-api get pdb go-api-drill-pdb -o yaml"
   tips:
     - "Start traffic FIRST — the availability check reads http_requests_total from Prometheus, which needs live requests to be meaningful."
+    - "Grafana → the linked availability dashboard: RPS and success rate should stay flat through the drain. A visible dip means the PDB or replica headroom wasn't enough to cover the eviction."
     - "The PDB uses maxUnavailable: 1, so at most one go-api pod can be evicted at a time; the drain blocks until a replacement is Ready elsewhere."
     - "On single-node clusters a drain has nowhere to reschedule pods. k3d defaults to 2 agents (AGENTS env var) precisely so this drill works."
     - "drain.sh always uncordons the node at the end, even on failure, so the cluster never gets stuck SchedulingDisabled."

--- a/scenarios/observability-sre/dashboards/sre-golden-signals.json
+++ b/scenarios/observability-sre/dashboards/sre-golden-signals.json
@@ -1,0 +1,137 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "title": "go-api: Request Rate by Status Code",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 16, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{app=\"go-api\"}[1m])) by (code)",
+          "legendFormat": "{{code}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 15, "stacking": { "mode": "normal" } },
+          "unit": "reqps"
+        }
+      }
+    },
+    {
+      "title": "Error Rate (SLO < 5%)",
+      "type": "stat",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{code=~\"5..\",app=\"go-api\"}[5m])) / clamp_min(sum(rate(http_requests_total{app=\"go-api\"}[5m])), 0.001)",
+          "legendFormat": "5xx rate"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 0.05 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "title": "go-api: p99 Latency (SLO < 1s)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 16, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{app=\"go-api\"}[5m])) by (le))",
+          "legendFormat": "p99"
+        },
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket{app=\"go-api\"}[5m])) by (le))",
+          "legendFormat": "p50"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "p99" },
+            "properties": [ { "id": "custom.lineWidth", "value": 3 } ]
+          }
+        ]
+      }
+    },
+    {
+      "title": "Pods Ready",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 8, "x": 16, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(kube_pod_status_ready{namespace=\"go-api\", condition=\"true\"})",
+          "legendFormat": "ready"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "title": "Memory Saturation (SLO < 85%)",
+      "type": "timeseries",
+      "gridPos": { "h": 4, "w": 8, "x": 16, "y": 12 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "max(container_memory_working_set_bytes{namespace=\"go-api\",container!=\"\"} / container_spec_memory_limit_bytes{namespace=\"go-api\",container!=\"\"})",
+          "legendFormat": "mem used / limit"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 },
+          "unit": "percentunit",
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 0.85 }
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["observability", "sre", "golden-signals", "go-api"],
+  "templating": { "list": [] },
+  "time": { "from": "now-30m", "to": "now" },
+  "title": "Observability & SRE — Golden Signals",
+  "uid": "observability-sre"
+}

--- a/scenarios/observability-sre/scenario.yaml
+++ b/scenarios/observability-sre/scenario.yaml
@@ -98,10 +98,15 @@ checks:
     url: "http://grafana.{{.DomainSuffix}}"
     expectStatus: 200
 
+snippets:
+  - label: "SRE alerting rules (error rate, latency, saturation, readiness)"
+    description: "A PrometheusRule with the golden-signal alerts this scenario installs: 5xx error rate, p99 latency, memory/CPU saturation, and pod readiness. Trip one with the traffic/fault commands and watch it fire."
+    path: manifests/alerting-rules.yaml
+
 explore:
   urls:
-    - label: "Grafana Dashboards"
-      url: "http://grafana.{{.DomainSuffix}}"
+    - label: "Grafana — SRE Golden Signals dashboard"
+      url: "http://grafana.{{.DomainSuffix}}/d/observability-sre"
     - label: "Prometheus"
       url: "http://prometheus.{{.DomainSuffix}}"
   commands:

--- a/scenarios/secrets-management/scenario.yaml
+++ b/scenarios/secrets-management/scenario.yaml
@@ -68,6 +68,11 @@ checks:
     type: script
     script: checks/verify-rotation.sh
 
+snippets:
+  - label: "External Secrets wiring: Vault SecretStore + ExternalSecret"
+    description: "The sync contract — a SecretStore pointing at Vault and an ExternalSecret that materializes a Kubernetes Secret from it. refreshInterval: 10s makes rotation visible quickly; rotate the value in Vault and watch it propagate."
+    path: manifests/es-wiring.yaml
+
 explore:
   urls:
     - label: "Vault UI"

--- a/scenarios/security-compliance/manifests/kyverno-policies.yaml
+++ b/scenarios/security-compliance/manifests/kyverno-policies.yaml
@@ -13,7 +13,6 @@ apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: deny-privilege-escalation
-  name: deny-privilege-escalation
   annotations:
     policies.kyverno.io/title: Deny Privilege Escalation
     policies.kyverno.io/category: Pod Security Standards
@@ -25,10 +24,8 @@ metadata:
       allowPrivilegeEscalation: false.
 spec:
   validationFailureAction: Audit
-  validationFailureAction: Audit
   background: true
   rules:
-    - name: deny-privilege-escalation
     - name: deny-privilege-escalation
       match:
         any:
@@ -51,7 +48,6 @@ spec:
             containers:
               - securityContext:
                   allowPrivilegeEscalation: false
-                  allowPrivilegeEscalation: false
 ---
 # Policy 2: Require non-root user
 # All containers must set runAsNonRoot: true to prevent processes running as
@@ -59,7 +55,6 @@ spec:
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
-  name: require-non-root-user
   name: require-non-root-user
   annotations:
     policies.kyverno.io/title: Require Non-Root User
@@ -101,9 +96,9 @@ spec:
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
-  name: require-explicit-image-tag
+  name: require-resource-limits
   annotations:
-    policies.kyverno.io/title: Require Explicit Image Tag
+    policies.kyverno.io/title: Require Resource Limits
     policies.kyverno.io/category: Best Practices
     policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
@@ -113,7 +108,7 @@ spec:
   validationFailureAction: Audit
   background: true
   rules:
-    - name: require-image-tag
+    - name: require-resource-limits
       match:
         any:
           - resources:
@@ -129,7 +124,7 @@ spec:
                 - argocd
                 - chaos-mesh
       validate:
-        message: "Images must use an explicit tag."
+        message: "Containers must declare CPU and memory limits."
         pattern:
           spec:
             containers:

--- a/scenarios/security-compliance/scenario.yaml
+++ b/scenarios/security-compliance/scenario.yaml
@@ -8,6 +8,8 @@ prerequisites:
     - ingress
     - monitoring/metrics
     - monitoring/grafana
+    - security/policy/kyverno
+    - security/tls/cert-manager
   apps:
     - go-api
 runtimes:
@@ -70,6 +72,14 @@ checks:
     type: kubectl
     resource: networkpolicy/default-deny-all
     namespace: go-api
+
+snippets:
+  - label: "Kyverno ClusterPolicies (no privilege escalation, non-root, explicit tags)"
+    description: "Pod-security and best-practice policies in Audit mode, so existing workloads aren't disrupted on activation. Review the policy reports, then switch to Enforce once violations are resolved."
+    path: manifests/kyverno-policies.yaml
+  - label: "Default-deny NetworkPolicies with explicit allow rules"
+    description: "Locks the go-api namespace to default-deny, then re-opens exactly what it needs: DNS, Traefik ingress, and Prometheus scraping — the model for zero-trust namespace isolation."
+    path: manifests/network-policies.yaml
 
 explore:
   urls:

--- a/src/.coverage-exceptions
+++ b/src/.coverage-exceptions
@@ -30,7 +30,6 @@ github.com/sagar2395/snowopslabs/internal/httpapi     43.6   W5  rebuilt as /api
 github.com/sagar2395/snowopslabs/internal/scenario    43.4   W4  rebuilt on the catalog + run engine
 github.com/sagar2395/snowopslabs/internal/runtime     59.0   W3  reduced to k3d/kind/incluster and moved onto the run engine
 github.com/sagar2395/snowopslabs/internal/services    55.9   W3  moved onto the run engine
-github.com/sagar2395/snowopslabs/internal/platform    76.5   W3  moved onto the run engine
 github.com/sagar2395/snowopslabs/internal/lab         76.3   W3  moved onto the run engine
 github.com/sagar2395/snowopslabs/internal/learn       76.7   W7  reworked with the assessment UI
 

--- a/src/engine/deploy.sh
+++ b/src/engine/deploy.sh
@@ -26,6 +26,50 @@ fi
 # Use explicit override if provided, otherwise use app.env default, otherwise fail
 DEPLOY_STRATEGY="${DEPLOY_STRATEGY:?app.env must define DEPLOY_STRATEGY or pass DEPLOY_STRATEGY=... on command line}"
 
+# A docker-built image lives only in the host Docker daemon; on k3d/kind it must
+# be loaded into the cluster or the pod hits ImagePullBackOff. `app build` did
+# this but `app deploy` didn't, so a deploy after a cluster re-create failed.
+# Load the image into the cluster before deploying.
+ensure_image_in_cluster() {
+  [ "${COMMAND}" = "deploy" ] || return 0
+  [ "${BUILD_STRATEGY:-}" = "docker" ] || return 0
+
+  local profile="${PROFILE:-k3d}"
+  local cluster="${CLUSTER_NAME:-snowops}"
+  local image="${APP_NAME}:${DOCKER_IMAGE_TAG:-latest}"
+
+  case "${profile}" in
+    k3d)
+      command -v k3d >/dev/null 2>&1 || return 0
+      if ! docker image inspect "${image}" >/dev/null 2>&1; then
+        echo "[deploy] Image ${image} not found in the local Docker daemon — building it first..."
+        bash "${ENGINE_DIR}/build.sh" "${APP_NAME}" # build.sh imports into k3d itself
+        return 0
+      fi
+      # Import is idempotent, so run it unconditionally rather than depend on the
+      # `k3d image list` output format (which varies across k3d versions).
+      echo "[deploy] Importing ${image} into k3d cluster '${cluster}'..."
+      k3d image import "${image}" -c "${cluster}"
+      ;;
+    kind)
+      command -v kind >/dev/null 2>&1 || return 0
+      if ! docker image inspect "${image}" >/dev/null 2>&1; then
+        echo "[deploy] Image ${image} not found in the local Docker daemon — building it first..."
+        bash "${ENGINE_DIR}/build.sh" "${APP_NAME}" # docker build only; kind load happens below
+      fi
+      # kind load is idempotent; the docker build strategy does not load into kind.
+      echo "[deploy] Loading ${image} into kind cluster '${cluster}'..."
+      kind load docker-image "${image}" --name "${cluster}"
+      ;;
+    *)
+      # incluster / registry-backed runtimes pull from a real registry — nothing to import.
+      :
+      ;;
+  esac
+}
+
+ensure_image_in_cluster
+
 STRATEGY_SCRIPT="${ENGINE_DIR}/deploy/${DEPLOY_STRATEGY}.sh"
 
 if [[ ! -f "${STRATEGY_SCRIPT}" ]]; then

--- a/src/internal/appdetail/detail.go
+++ b/src/internal/appdetail/detail.go
@@ -94,7 +94,7 @@ func description(appDir string) string {
 	if err != nil {
 		return ""
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	sc := bufio.NewScanner(f)
 	for sc.Scan() {
 		line := strings.TrimSpace(sc.Text())
@@ -112,7 +112,7 @@ func firstProse(path string) string {
 	if err != nil {
 		return ""
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	sc := bufio.NewScanner(f)
 	for sc.Scan() {
 		line := strings.TrimSpace(sc.Text())

--- a/src/internal/appdetail/detail.go
+++ b/src/internal/appdetail/detail.go
@@ -37,7 +37,6 @@ type Detail struct {
 	Dockerfile     *FileRef `json:"dockerfile,omitempty"`
 	ChartYAML      *FileRef `json:"chartYaml,omitempty"`
 	ValuesFile     *FileRef `json:"valuesFile,omitempty"`
-	Entrypoint     *FileRef `json:"entrypoint,omitempty"`
 	HelmChartPath  string   `json:"helmChartPath,omitempty"`
 	Templates      []string `json:"templates,omitempty"`
 }
@@ -63,9 +62,6 @@ func Build(projectRoot, name, buildStrategy, deployStrategy, namespace, valuesFi
 
 	if fr := readFile(projectRoot, filepath.Join(appDir, "Dockerfile")); fr != nil {
 		d.Dockerfile = fr
-	}
-	if fr := entrypoint(projectRoot, appDir); fr != nil {
-		d.Entrypoint = fr
 	}
 
 	chartDir := filepath.Join(appDir, "deploy", "helm")
@@ -150,16 +146,6 @@ func detectTech(appDir string) []string {
 		add("Kubernetes")
 	}
 	return tech
-}
-
-// entrypoint returns the app's main source file, if it has a recognisable one.
-func entrypoint(projectRoot, appDir string) *FileRef {
-	for _, cand := range []string{"main.go", "main.py", "index.js", "server.js", "app.py"} {
-		if p := filepath.Join(appDir, cand); exists(p) {
-			return readFile(projectRoot, p)
-		}
-	}
-	return nil
 }
 
 // templateList returns the Helm template filenames (repo-relative), so the page

--- a/src/internal/appdetail/detail.go
+++ b/src/internal/appdetail/detail.go
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package appdetail assembles the "how is this app built and deployed" view for
+// the UI: a plain-English overview plus the actual Dockerfile and Helm chart a
+// learner would edit, each tagged with its path from the repo root so they can
+// open it and play with building/deploying the app.
+package appdetail
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// maxFileBytes caps how much of any single file we inline, so a runaway file
+// can't bloat the response. Dockerfiles and values files are far smaller.
+const maxFileBytes = 24 * 1024
+
+// FileRef is one source file surfaced on the details page: its path from the
+// repo root (clickable/greppable) and its (possibly truncated) content.
+type FileRef struct {
+	Path      string `json:"path"`
+	Content   string `json:"content"`
+	Truncated bool   `json:"truncated"`
+}
+
+// Detail is the per-app payload: what the app is, the stack it uses, and the
+// build/deploy artifacts with their in-repo locations.
+type Detail struct {
+	Name           string   `json:"name"`
+	Description    string   `json:"description"`
+	Tech           []string `json:"tech"`
+	BuildStrategy  string   `json:"buildStrategy"`
+	DeployStrategy string   `json:"deployStrategy"`
+	Namespace      string   `json:"namespace"`
+	Dockerfile     *FileRef `json:"dockerfile,omitempty"`
+	ChartYAML      *FileRef `json:"chartYaml,omitempty"`
+	ValuesFile     *FileRef `json:"valuesFile,omitempty"`
+	Entrypoint     *FileRef `json:"entrypoint,omitempty"`
+	HelmChartPath  string   `json:"helmChartPath,omitempty"`
+	Templates      []string `json:"templates,omitempty"`
+}
+
+// Build reads an app's on-disk layout under apps/<name> and assembles its
+// details. Missing optional files (a README, a Dockerfile) are simply omitted;
+// the caller still gets whatever is present. valuesFile names the Helm values
+// file the app deploys with (from app.env HELM_VALUES), so the page shows the
+// same file the Deploy button uses.
+func Build(projectRoot, name, buildStrategy, deployStrategy, namespace, valuesFile string) Detail {
+	appDir := filepath.Join(projectRoot, "apps", name)
+	if namespace == "" {
+		namespace = name
+	}
+	d := Detail{
+		Name:           name,
+		BuildStrategy:  buildStrategy,
+		DeployStrategy: deployStrategy,
+		Namespace:      namespace,
+		Description:    description(appDir),
+		Tech:           detectTech(appDir),
+	}
+
+	if fr := readFile(projectRoot, filepath.Join(appDir, "Dockerfile")); fr != nil {
+		d.Dockerfile = fr
+	}
+	if fr := entrypoint(projectRoot, appDir); fr != nil {
+		d.Entrypoint = fr
+	}
+
+	chartDir := filepath.Join(appDir, "deploy", "helm")
+	if _, err := os.Stat(chartDir); err == nil {
+		d.HelmChartPath = repoRel(projectRoot, chartDir)
+		if fr := readFile(projectRoot, filepath.Join(chartDir, "Chart.yaml")); fr != nil {
+			d.ChartYAML = fr
+		}
+		if valuesFile == "" {
+			valuesFile = "values.yaml"
+		}
+		if fr := readFile(projectRoot, filepath.Join(chartDir, valuesFile)); fr != nil {
+			d.ValuesFile = fr
+		} else if fr := readFile(projectRoot, filepath.Join(chartDir, "values.yaml")); fr != nil {
+			d.ValuesFile = fr
+		}
+		d.Templates = templateList(projectRoot, filepath.Join(chartDir, "templates"))
+	}
+	return d
+}
+
+// description returns a one-paragraph summary: the first real prose line of the
+// app's README, else the Helm chart's description, else "".
+func description(appDir string) string {
+	if p := firstProse(filepath.Join(appDir, "README.md")); p != "" {
+		return p
+	}
+	// Chart.yaml description as a fallback.
+	f, err := os.Open(filepath.Join(appDir, "deploy", "helm", "Chart.yaml"))
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if strings.HasPrefix(line, "description:") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "description:"))
+		}
+	}
+	return ""
+}
+
+// firstProse returns the first non-empty, non-heading, non-badge line of a
+// Markdown file — the sentence a reader would take as the summary.
+func firstProse(path string) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "![") || strings.HasPrefix(line, "[!") {
+			continue
+		}
+		return line
+	}
+	return ""
+}
+
+// detectTech infers the stack from files present in the app directory, in a
+// stable display order.
+func detectTech(appDir string) []string {
+	var tech []string
+	add := func(t string) { tech = append(tech, t) }
+	if exists(filepath.Join(appDir, "go.mod")) {
+		add("Go")
+	}
+	if exists(filepath.Join(appDir, "package.json")) {
+		add("Node.js")
+	}
+	if exists(filepath.Join(appDir, "requirements.txt")) || exists(filepath.Join(appDir, "pyproject.toml")) {
+		add("Python")
+	}
+	if exists(filepath.Join(appDir, "Dockerfile")) {
+		add("Docker")
+	}
+	if exists(filepath.Join(appDir, "deploy", "helm")) {
+		add("Helm")
+		add("Kubernetes")
+	}
+	return tech
+}
+
+// entrypoint returns the app's main source file, if it has a recognisable one.
+func entrypoint(projectRoot, appDir string) *FileRef {
+	for _, cand := range []string{"main.go", "main.py", "index.js", "server.js", "app.py"} {
+		if p := filepath.Join(appDir, cand); exists(p) {
+			return readFile(projectRoot, p)
+		}
+	}
+	return nil
+}
+
+// templateList returns the Helm template filenames (repo-relative), so the page
+// can point at the manifests without inlining all of them.
+func templateList(projectRoot, templatesDir string) []string {
+	entries, err := os.ReadDir(templatesDir)
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		out = append(out, repoRel(projectRoot, filepath.Join(templatesDir, e.Name())))
+	}
+	return out
+}
+
+func readFile(projectRoot, path string) *FileRef {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	truncated := false
+	if len(data) > maxFileBytes {
+		data = data[:maxFileBytes]
+		truncated = true
+	}
+	return &FileRef{Path: repoRel(projectRoot, path), Content: string(data), Truncated: truncated}
+}
+
+// repoRel returns path relative to the repo root (falling back to the absolute
+// path if it somehow escapes the tree), using forward slashes.
+func repoRel(projectRoot, path string) string {
+	rel, err := filepath.Rel(projectRoot, path)
+	if err != nil {
+		return filepath.ToSlash(path)
+	}
+	return filepath.ToSlash(rel)
+}
+
+func exists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/src/internal/appdetail/detail_coverage_test.go
+++ b/src/internal/appdetail/detail_coverage_test.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+package appdetail
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeApp creates apps/<name>/<relpath> files under a temp project root and
+// returns the root, so tests can drive Build against a controlled layout.
+func writeApp(t *testing.T, name string, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for rel, content := range files {
+		full := filepath.Join(root, "apps", name, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+// Description falls back to the Helm chart's description when there is no README.
+func TestBuild_DescriptionFallsBackToChart(t *testing.T) {
+	root := writeApp(t, "svc", map[string]string{
+		"deploy/helm/Chart.yaml": "name: svc\ndescription: A synthetic service\nversion: 0.1.0\n",
+	})
+	d := Build(root, "svc", "docker", "helm", "", "values.yaml")
+	if d.Description != "A synthetic service" {
+		t.Errorf("Description = %q, want the Chart.yaml description", d.Description)
+	}
+}
+
+// README prose wins over the chart description, skipping headings and badges.
+func TestBuild_DescriptionPrefersReadmeProse(t *testing.T) {
+	root := writeApp(t, "svc", map[string]string{
+		"README.md":              "# Title\n\n![badge](x)\n[!note]\n\nThe real summary line.\n",
+		"deploy/helm/Chart.yaml": "name: svc\ndescription: chart desc\n",
+	})
+	d := Build(root, "svc", "docker", "helm", "", "values.yaml")
+	if d.Description != "The real summary line." {
+		t.Errorf("Description = %q, want the README prose line", d.Description)
+	}
+}
+
+// With neither a README nor a chart, description is empty (no error).
+func TestBuild_DescriptionEmptyWhenNothing(t *testing.T) {
+	root := writeApp(t, "svc", map[string]string{"main.py": "print('hi')\n"})
+	d := Build(root, "svc", "docker", "helm", "", "values.yaml")
+	if d.Description != "" {
+		t.Errorf("Description = %q, want empty", d.Description)
+	}
+}
+
+func TestDetectTech_NodeAndPython(t *testing.T) {
+	rootNode := writeApp(t, "web", map[string]string{"package.json": "{}", "Dockerfile": "FROM node"})
+	if tech := Build(rootNode, "web", "", "", "", "").Tech; !contains(tech, "Node.js") || !contains(tech, "Docker") {
+		t.Errorf("Node app tech = %v", tech)
+	}
+	rootPy := writeApp(t, "api", map[string]string{"requirements.txt": "flask\n"})
+	if tech := Build(rootPy, "api", "", "", "", "").Tech; !contains(tech, "Python") {
+		t.Errorf("Python (requirements) tech = %v", tech)
+	}
+	rootPy2 := writeApp(t, "api", map[string]string{"pyproject.toml": "[project]\n"})
+	if tech := Build(rootPy2, "api", "", "", "", "").Tech; !contains(tech, "Python") {
+		t.Errorf("Python (pyproject) tech = %v", tech)
+	}
+}
+
+// A file larger than maxFileBytes is truncated and flagged.
+func TestReadFile_Truncates(t *testing.T) {
+	big := strings.Repeat("x", maxFileBytes+500)
+	root := writeApp(t, "svc", map[string]string{"Dockerfile": big})
+	d := Build(root, "svc", "docker", "helm", "", "values.yaml")
+	if d.Dockerfile == nil {
+		t.Fatal("expected a Dockerfile FileRef")
+	}
+	if !d.Dockerfile.Truncated {
+		t.Error("expected Truncated = true for an oversized file")
+	}
+	if len(d.Dockerfile.Content) != maxFileBytes {
+		t.Errorf("truncated content len = %d, want %d", len(d.Dockerfile.Content), maxFileBytes)
+	}
+}
+
+// A small file is returned whole and not flagged.
+func TestReadFile_NotTruncated(t *testing.T) {
+	root := writeApp(t, "svc", map[string]string{"Dockerfile": "FROM scratch\n"})
+	d := Build(root, "svc", "docker", "helm", "", "values.yaml")
+	if d.Dockerfile == nil || d.Dockerfile.Truncated {
+		t.Errorf("small Dockerfile should be present and untruncated: %+v", d.Dockerfile)
+	}
+	if d.Dockerfile.Path != "apps/svc/Dockerfile" {
+		t.Errorf("Dockerfile path = %q", d.Dockerfile.Path)
+	}
+}

--- a/src/internal/appdetail/detail_test.go
+++ b/src/internal/appdetail/detail_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+package appdetail
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// repoRoot resolves the repository root from this package's directory so the
+// test reads the real apps/ layout it describes.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.Abs(filepath.Join("..", "..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+	return root
+}
+
+func TestBuild_GoAPI(t *testing.T) {
+	d := Build(repoRoot(t), "go-api", "docker", "helm", "", "values-dev.yaml")
+
+	if d.Namespace != "go-api" {
+		t.Errorf("Namespace default: got %q, want go-api", d.Namespace)
+	}
+	if d.Dockerfile == nil || !strings.HasPrefix(d.Dockerfile.Path, "apps/go-api/Dockerfile") {
+		t.Errorf("Dockerfile: got %+v, want apps/go-api/Dockerfile", d.Dockerfile)
+	}
+	if d.ChartYAML == nil || !strings.Contains(d.ChartYAML.Content, "name: go-api") {
+		t.Errorf("ChartYAML missing or wrong content: %+v", d.ChartYAML)
+	}
+	if d.ValuesFile == nil || d.ValuesFile.Path != "apps/go-api/deploy/helm/values-dev.yaml" {
+		t.Errorf("ValuesFile: got %+v, want the app.env values-dev.yaml", d.ValuesFile)
+	}
+	if d.HelmChartPath != "apps/go-api/deploy/helm" {
+		t.Errorf("HelmChartPath: got %q", d.HelmChartPath)
+	}
+	if !contains(d.Tech, "Go") || !contains(d.Tech, "Docker") || !contains(d.Tech, "Helm") {
+		t.Errorf("Tech detection incomplete: %v", d.Tech)
+	}
+	if len(d.Templates) == 0 {
+		t.Errorf("expected Helm templates to be listed")
+	}
+	for _, tpl := range d.Templates {
+		if !strings.HasPrefix(tpl, "apps/go-api/deploy/helm/templates/") {
+			t.Errorf("template path not repo-rooted: %q", tpl)
+		}
+	}
+}
+
+// A values file that doesn't exist should fall back to values.yaml, not 404.
+func TestBuild_ValuesFallback(t *testing.T) {
+	d := Build(repoRoot(t), "go-api", "docker", "helm", "", "values-nonexistent.yaml")
+	if d.ValuesFile == nil || d.ValuesFile.Path != "apps/go-api/deploy/helm/values.yaml" {
+		t.Errorf("expected fallback to values.yaml, got %+v", d.ValuesFile)
+	}
+}
+
+func contains(s []string, v string) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}

--- a/src/internal/cli/hosts.go
+++ b/src/internal/cli/hosts.go
@@ -29,6 +29,7 @@ var knownSubdomains = []string{
 	"argocd",
 	"traefik",
 	"kubernetes-dashboard",
+	"chaos", // chaos-engineering: Chaos Mesh dashboard ingress
 }
 
 var hostsCmd = &cobra.Command{

--- a/src/internal/cli/init_cmd.go
+++ b/src/internal/cli/init_cmd.go
@@ -3,6 +3,7 @@ package cli
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -57,9 +58,23 @@ func printPostInitHints() {
 
 var teardownCmd = &cobra.Command{
 	Use:   "teardown",
-	Short: "Tear down the lab (destroy apps + platform + cluster)",
+	Short: "Tear down the lab (deactivate scenarios/incidents + destroy apps + platform + cluster)",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		fmt.Println("=== Destroying all apps ===")
+		// Deactivate scenarios and incidents FIRST — before their platform/app
+		// prerequisites are destroyed. Their state markers live on disk and would
+		// otherwise survive the teardown, leaving scenarios/incidents reading as
+		// "active" against a cluster where nothing they rely on exists.
+		fmt.Println("=== Deactivating scenarios and incidents ===")
+		if cleared := scenes.DeactivateAll(); len(cleared) > 0 {
+			fmt.Printf("Deactivated scenarios: %s\n", strings.Join(cleared, ", "))
+		}
+		if incEng != nil {
+			if fault := incEng.ClearActiveState(); fault != "" {
+				fmt.Printf("Deactivated incident: %s\n", fault)
+			}
+		}
+
+		fmt.Println("\n=== Destroying all apps ===")
 		apps, _ := config.ListApps(cfg.ProjectRoot)
 		for _, app := range apps {
 			fmt.Printf("Destroying %s...\n", app)

--- a/src/internal/cli/init_cmd.go
+++ b/src/internal/cli/init_cmd.go
@@ -36,9 +36,6 @@ var initCmd = &cobra.Command{
 	},
 }
 
-// printPostInitHints tells the user the two things that trip people up right
-// after init: ingress hostnames need an /etc/hosts entry to resolve, and apps
-// must be deployed before scenarios/challenges can use them.
 func printPostInitHints() {
 	suffix := cfg.DomainSuffix
 	if suffix == "" {
@@ -60,10 +57,7 @@ var teardownCmd = &cobra.Command{
 	Use:   "teardown",
 	Short: "Tear down the lab (deactivate scenarios/incidents + destroy apps + platform + cluster)",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// Deactivate scenarios and incidents FIRST — before their platform/app
-		// prerequisites are destroyed. Their state markers live on disk and would
-		// otherwise survive the teardown, leaving scenarios/incidents reading as
-		// "active" against a cluster where nothing they rely on exists.
+		// Deactivate scenarios and incidents FIRST — before their platform/app prerequisites are destroyed.
 		fmt.Println("=== Deactivating scenarios and incidents ===")
 		if cleared := scenes.DeactivateAll(); len(cleared) > 0 {
 			fmt.Printf("Deactivated scenarios: %s\n", strings.Join(cleared, ", "))

--- a/src/internal/cli/lab.go
+++ b/src/internal/cli/lab.go
@@ -164,8 +164,23 @@ stays up. Tip: take a snapshot first — labctl lab snapshot before-reset.`,
 		}
 
 		// Continue on error: tear down as much as possible, report what stuck.
-		if err := lab.Execute(plan, labDeps(true)); err != nil {
-			return err
+		execErr := lab.Execute(plan, labDeps(true))
+
+		// Force-clear scenario and incident activation state regardless of how
+		// teardown went — after a reset their prerequisites are gone, so they must
+		// read as inactive (and be re-activatable) even if a component teardown
+		// failed part-way.
+		if cleared := scenes.DeactivateAll(); len(cleared) > 0 {
+			fmt.Printf("Deactivated scenarios: %s\n", strings.Join(cleared, ", "))
+		}
+		if incEng != nil {
+			if fault := incEng.ClearActiveState(); fault != "" {
+				fmt.Printf("Deactivated incident: %s\n", fault)
+			}
+		}
+
+		if execErr != nil {
+			return execErr
 		}
 		fmt.Println("\nLab reset to post-init state.")
 		return nil

--- a/src/internal/cli/lab.go
+++ b/src/internal/cli/lab.go
@@ -166,10 +166,7 @@ stays up. Tip: take a snapshot first — labctl lab snapshot before-reset.`,
 		// Continue on error: tear down as much as possible, report what stuck.
 		execErr := lab.Execute(plan, labDeps(true))
 
-		// Force-clear scenario and incident activation state regardless of how
-		// teardown went — after a reset their prerequisites are gone, so they must
-		// read as inactive (and be re-activatable) even if a component teardown
-		// failed part-way.
+		// Force-clear scenario and incident activation state
 		if cleared := scenes.DeactivateAll(); len(cleared) > 0 {
 			fmt.Printf("Deactivated scenarios: %s\n", strings.Join(cleared, ", "))
 		}

--- a/src/internal/cli/scenario.go
+++ b/src/internal/cli/scenario.go
@@ -20,6 +20,7 @@ import (
 var scenarioNewForce bool
 var scenarioUpForce bool
 var scenarioDeployPrereqs bool
+var scenarioUpParams map[string]string
 
 var scenarioNewCmd = &cobra.Command{
 	Use:   "new <name>",
@@ -105,7 +106,7 @@ var scenarioUpCmd = &cobra.Command{
 			return nil
 		}
 		return runScenarioOp(cmd, "activate", name, func(ctx context.Context, svc *scnsvc.Service) (string, error) {
-			return svc.Activate(ctx, name, scenarioUpForce)
+			return svc.ActivateWithParams(ctx, name, scenarioUpForce, scenarioUpParams)
 		})
 	},
 }
@@ -408,6 +409,7 @@ func init() {
 	scenarioNewCmd.Flags().BoolVar(&scenarioNewForce, "force", false, "overwrite the scenario if it already exists")
 	scenarioUpCmd.Flags().BoolVar(&scenarioUpForce, "force", false, "reinstall even if the scenario is already active")
 	scenarioUpCmd.Flags().BoolVar(&scenarioDeployPrereqs, "deploy-prereqs", false, "build and deploy any prerequisite apps that are not yet running")
+	scenarioUpCmd.Flags().StringToStringVar(&scenarioUpParams, "set", nil, "override a scenario parameter (repeatable): --set key=value (e.g. --set threshold=15 --set maxReplicas=4)")
 
 	scenarioCmd.AddCommand(scenarioNewCmd)
 	scenarioCmd.AddCommand(scenarioListCmd)

--- a/src/internal/cli/ui.go
+++ b/src/internal/cli/ui.go
@@ -56,9 +56,6 @@ var uiCmd = &cobra.Command{
 		// Try to open browser
 		go openBrowser(url)
 
-		// Refuse to start on a port another process already holds — otherwise the
-		// old server keeps serving its (now stale) bundle and a "restart" looks
-		// like it worked while showing old code.
 		if ln, err := net.Listen("tcp", addr); err != nil {
 			return fmt.Errorf("cannot bind %s: %w\nAnother `labctl ui` may already be running — stop it first (e.g. pkill -f 'labctl ui'), or choose another --port", addr, err)
 		} else {

--- a/src/internal/cli/ui.go
+++ b/src/internal/cli/ui.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/fs"
 	"net"
+	"os"
 	osExec "os/exec"
 	"runtime"
 
@@ -21,6 +22,7 @@ var (
 	uiBind    string
 	uiTLSCert string
 	uiTLSKey  string
+	uiDir     string
 )
 
 var uiCmd = &cobra.Command{
@@ -54,17 +56,31 @@ var uiCmd = &cobra.Command{
 		// Try to open browser
 		go openBrowser(url)
 
+		// Refuse to start on a port another process already holds — otherwise the
+		// old server keeps serving its (now stale) bundle and a "restart" looks
+		// like it worked while showing old code.
+		if ln, err := net.Listen("tcp", addr); err != nil {
+			return fmt.Errorf("cannot bind %s: %w\nAnother `labctl ui` may already be running — stop it first (e.g. pkill -f 'labctl ui'), or choose another --port", addr, err)
+		} else {
+			_ = ln.Close()
+		}
+
 		// Use embedded UI assets (sub-directory "dist" within the embed.FS)
 		uiFS, _ := fs.Sub(webui.DistFS, "dist")
 
 		// Optional Prometheus endpoint, off unless LABCTL_METRICS=true.
 		var opts []httpapi.ServerOption
+		if uiDir != "" {
+			opts = append(opts, httpapi.WithUIDir(uiDir))
+		}
 		if metrics.Enabled() {
 			opts = append(opts, httpapi.WithMetrics(metrics.NewApp(rootCmd.Version)))
 			fmt.Printf("Metrics enabled at %s/metrics\n", url)
 		}
 
 		server := httpapi.NewServer(cfg, exec, reg, scenes, incEng, svcReg, rtm, uiFS, opts...)
+		// Name the exact bundle being served so a stale process is obvious.
+		fmt.Printf("Serving %s\n", server.UIInfo())
 		if uiTLSCert != "" {
 			return server.StartTLS(addr, uiTLSCert, uiTLSKey)
 		}
@@ -99,5 +115,6 @@ func init() {
 	uiCmd.Flags().StringVar(&uiBind, "bind", "127.0.0.1", "address to bind (use 0.0.0.0 to expose on the network; requires auth)")
 	uiCmd.Flags().StringVar(&uiTLSCert, "tls-cert", "", "path to a TLS certificate (PEM); enables HTTPS when set with --tls-key")
 	uiCmd.Flags().StringVar(&uiTLSKey, "tls-key", "", "path to the TLS private key (PEM)")
+	uiCmd.Flags().StringVar(&uiDir, "ui-dir", os.Getenv("LABCTL_UI_DIR"), "serve the UI live from this directory (e.g. src/ui/dist) instead of the embedded bundle; defaults to $LABCTL_UI_DIR")
 	rootCmd.AddCommand(uiCmd)
 }

--- a/src/internal/httpapi/handlers.go
+++ b/src/internal/httpapi/handlers.go
@@ -3,9 +3,11 @@ package httpapi
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"regexp"
 	"strings"
@@ -57,6 +59,9 @@ type AppStatusResp struct {
 	// app's ingress to be enabled and the host resolvable (a /etc/hosts entry
 	// for k3d/kind), which the UI notes.
 	URL string `json:"url,omitempty"`
+	// HPA carries live autoscaler state when an HPA (KEDA-managed included)
+	// targets the app; nil otherwise, so the UI shows the plain replica count.
+	HPA *k8s.HPAStatus `json:"hpa,omitempty"`
 }
 
 // appURL builds the conventional ingress URL for a deployed app, or "" when the
@@ -138,6 +143,13 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 				appResp.Replicas = status.Replicas
 				appResp.Ready = status.Ready
 			}
+			// Surface live autoscaler state so the UI can show why the app scaled,
+			// without a terminal. Only worth querying once it's deployed.
+			if appResp.Deployed {
+				if hpa, err := k8s.GetHPAStatus(ctx, ns, appName); err == nil && hpa.Present {
+					appResp.HPA = hpa
+				}
+			}
 			appResp.URL = appURL(appName, s.cfg.DomainSuffix, appResp.Deployed)
 		}
 		resp.Apps = append(resp.Apps, appResp)
@@ -172,6 +184,13 @@ func (s *Server) handleListApps(w http.ResponseWriter, r *http.Request) {
 				appResp.Deployed = status.Deployed
 				appResp.Replicas = status.Replicas
 				appResp.Ready = status.Ready
+			}
+			// Surface live autoscaler state so the UI can answer "why did it
+			// scale" without a terminal. Only worth querying once the app is up.
+			if appResp.Deployed {
+				if hpa, err := k8s.GetHPAStatus(ctx, ns, appName); err == nil && hpa.Present {
+					appResp.HPA = hpa
+				}
 			}
 			appResp.URL = appURL(appName, s.cfg.DomainSuffix, appResp.Deployed)
 		}
@@ -382,6 +401,96 @@ func (s *Server) handleComponentDown(w http.ResponseWriter, r *http.Request) {
 	respondJSON(w, http.StatusAccepted, map[string]string{"jobId": jobID, "status": "accepted"})
 }
 
+// ScenarioRef is a compact scenario pointer for the "used in" list.
+type ScenarioRef struct {
+	Name        string `json:"name"`
+	DisplayName string `json:"displayName"`
+}
+
+// PlatformComponentDetail is the per-tool details payload: what it is, how it's
+// installed, and which scenarios depend on it.
+type PlatformComponentDetail struct {
+	Category        string        `json:"category"`
+	Name            string        `json:"name"`
+	Namespace       string        `json:"namespace"`
+	Installed       bool          `json:"installed"`
+	Description     string        `json:"description"`
+	Provides        []string      `json:"provides"`
+	Ports           []string      `json:"ports"`
+	Dependencies    []string      `json:"dependencies"`
+	Resources       []string      `json:"resources"`
+	Chart           string        `json:"chart"`
+	InstallCommands []string      `json:"installCommands"`
+	UsedInScenarios []ScenarioRef `json:"usedInScenarios"`
+}
+
+// nonNilStrings returns s, or an empty (non-nil) slice when s is nil, so it
+// marshals to a JSON [] instead of null — the UI indexes .length on these.
+func nonNilStrings(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+	return s
+}
+
+func (s *Server) handlePlatformComponentDetail(w http.ResponseWriter, r *http.Request) {
+	category := mux.Vars(r)["category"]
+	name := mux.Vars(r)["name"]
+	if !isValidName(category) || !isValidName(name) {
+		respondError(w, r, http.StatusBadRequest, "invalid_input", "invalid category or component name: must match ^[a-zA-Z0-9_-]{1,64}$")
+		return
+	}
+	category = s.resolveCategory(category)
+	p, err := s.registry.GetProvider(category, name)
+	if err != nil {
+		respondError(w, r, http.StatusNotFound, "not_found", err.Error())
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+	installed := k8s.NamespaceExists(ctx, p.Namespace())
+	if p.SharesNamespace() {
+		installed = k8s.HelmReleaseExists(ctx, p.Namespace(), p.Name)
+	}
+
+	meta := p.Meta()
+	// Guarantee non-nil slices: a Go nil slice marshals to JSON null, and the UI
+	// reads e.g. detail.provides.length — a null there crashes the details view.
+	detail := PlatformComponentDetail{
+		Category:        category,
+		Name:            name,
+		Namespace:       p.Namespace(),
+		Installed:       installed,
+		Description:     meta.Description,
+		Provides:        nonNilStrings(meta.Provides),
+		Ports:           nonNilStrings(meta.Ports),
+		Dependencies:    nonNilStrings(meta.Dependencies),
+		Resources:       nonNilStrings(meta.Resources),
+		Chart:           meta.Chart,
+		InstallCommands: nonNilStrings(p.InstallCommands()),
+		UsedInScenarios: s.scenariosUsingComponent(category, name),
+	}
+	respondJSON(w, http.StatusOK, detail)
+}
+
+// scenariosUsingComponent returns the scenarios whose platform prerequisites
+// reference this component, matching by full "category/name" key, bare category,
+// or bare name — the three forms scenarios use to name a prerequisite.
+func (s *Server) scenariosUsingComponent(category, name string) []ScenarioRef {
+	full := category + "/" + name
+	out := []ScenarioRef{}
+	for _, sc := range s.scenes.List() {
+		for _, prereq := range sc.Prerequisites.Platform {
+			if prereq == full || prereq == category || prereq == name {
+				out = append(out, ScenarioRef{Name: sc.Name, DisplayName: sc.DisplayName})
+				break
+			}
+		}
+	}
+	return out
+}
+
 func (s *Server) handleListScenarios(w http.ResponseWriter, r *http.Request) {
 	respondCatalog(w, r, s.scenes.Status())
 }
@@ -398,18 +507,43 @@ func (s *Server) handleScenarioInfo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Resolve template variables in explore URLs and commands
-	for i := range sc.Explore.URLs {
-		sc.Explore.URLs[i].URL = s.scenes.ResolveTemplate(sc.Explore.URLs[i].URL)
+	// Resolve template vars for display, using the scenario's parameter defaults
+	// so {{.Param}} shows a real value. Work on a copy with fresh slices — sc is
+	// the cached scenario and must not be mutated.
+	defaults := s.scenes.ParamDefaults(sc)
+	resolve := func(in string) string { return s.scenes.ResolveTemplateWithParams(in, defaults) }
+	resp := *sc
+
+	urls := make([]scenario.ExploreURL, len(sc.Explore.URLs))
+	for i, u := range sc.Explore.URLs {
+		u.URL = resolve(u.URL)
+		urls[i] = u
 	}
-	for i := range sc.Explore.Commands {
-		sc.Explore.Commands[i].Command = s.scenes.ResolveTemplate(sc.Explore.Commands[i].Command)
+	cmds := make([]scenario.ExploreCommand, len(sc.Explore.Commands))
+	for i, c := range sc.Explore.Commands {
+		c.Command = resolve(c.Command)
+		cmds[i] = c
 	}
-	for i := range sc.Explore.Tips {
-		sc.Explore.Tips[i] = s.scenes.ResolveTemplate(sc.Explore.Tips[i])
+	tips := make([]string, len(sc.Explore.Tips))
+	for i, t := range sc.Explore.Tips {
+		tips[i] = resolve(t)
+	}
+	resp.Explore = scenario.Explore{URLs: urls, Commands: cmds, Tips: tips}
+
+	// Inline each snippet's content (from its file or inline YAML) so the UI can
+	// show the actual manifest a learner would apply.
+	if len(sc.Snippets) > 0 {
+		snips := make([]scenario.Snippet, len(sc.Snippets))
+		for i, sn := range sc.Snippets {
+			if content, err := s.scenes.SnippetContent(sc, sn); err == nil {
+				sn.YAML = content
+			}
+			snips[i] = sn
+		}
+		resp.Snippets = snips
 	}
 
-	respondJSON(w, http.StatusOK, sc)
+	respondJSON(w, http.StatusOK, resp)
 }
 
 func (s *Server) handleScenarioUp(w http.ResponseWriter, r *http.Request) {
@@ -418,10 +552,23 @@ func (s *Server) handleScenarioUp(w http.ResponseWriter, r *http.Request) {
 		respondError(w, r, http.StatusBadRequest, "invalid_input", fmt.Sprintf("invalid scenario name %q: must match ^[a-zA-Z0-9_-]{1,64}$", name))
 		return
 	}
+	// Optional scenario parameter overrides: {"params": {"threshold": "15", ...}}.
+	// An empty or absent body means "use the defaults" — same as before.
+	var body struct {
+		Params map[string]string `json:"params"`
+	}
+	if r.Body != nil {
+		_ = json.NewDecoder(r.Body).Decode(&body) // tolerate an empty body
+	}
+
 	jobID := s.exec.NextActionID()
 	label := fmt.Sprintf("Activate scenario: %s", name)
 	s.exec.BroadcastStart(jobID, label)
 	go func() {
+		// Stage overrides for this activation only (serialised per engine, like
+		// the existing SetOutput usage).
+		s.scenes.SetActivationParams(body.Params)
+		defer s.scenes.SetActivationParams(nil)
 		s.exec.BroadcastEnd(jobID, label, s.scenes.Up(name, s.exec, false))
 	}()
 	respondJSON(w, http.StatusAccepted, map[string]string{"jobId": jobID, "status": "accepted"})
@@ -592,7 +739,7 @@ func (s *Server) handleDashboardURLs(w http.ResponseWriter, r *http.Request) {
 	if k8s.ServiceExists(ctx, monitoringNS, "loki-gateway") {
 		dashboards = append(dashboards, DashboardURL{
 			Name: "loki", Label: "Logs (Loki)",
-			URL:       fmt.Sprintf("http://grafana.%s/explore?orgId=1&left=%%7B%%22datasource%%22:%%22Loki%%22%%7D", domain),
+			URL:       grafanaExploreURL(domain, "loki", "loki", ""),
 			Available: true, Category: "monitoring",
 		})
 	}
@@ -600,12 +747,46 @@ func (s *Server) handleDashboardURLs(w http.ResponseWriter, r *http.Request) {
 	if k8s.ServiceExists(ctx, monitoringNS, "tempo") {
 		dashboards = append(dashboards, DashboardURL{
 			Name: "tempo", Label: "Traces (Tempo)",
-			URL:       fmt.Sprintf("http://grafana.%s/explore?orgId=1&left=%%7B%%22datasource%%22:%%22Tempo%%22%%7D", domain),
+			URL:       grafanaExploreURL(domain, "tempo", "tempo", ""),
 			Available: true, Category: "monitoring",
 		})
 	}
 
 	respondJSON(w, http.StatusOK, dashboards)
+}
+
+// grafanaExploreURL builds a Grafana Explore deep link for a datasource. Grafana
+// 11+ replaced the old ?left=<json> parameter with ?panes=<json> keyed by a pane
+// id, and resolves the datasource by UID (not name) — so a name-based link opens
+// an empty Explore. The datasources are provisioned with stable UIDs
+// (loki/tempo/prometheus), which these links reference. expr may be empty to open
+// Explore with the datasource selected and no pre-filled query.
+func grafanaExploreURL(domain, dsType, dsUID, expr string) string {
+	type dsRef struct {
+		Type string `json:"type"`
+		UID  string `json:"uid"`
+	}
+	type query struct {
+		RefID      string `json:"refId"`
+		Datasource dsRef  `json:"datasource"`
+		Expr       string `json:"expr,omitempty"`
+	}
+	type pane struct {
+		Datasource string            `json:"datasource"`
+		Queries    []query           `json:"queries"`
+		Range      map[string]string `json:"range"`
+	}
+	panes := map[string]pane{
+		"exp": {
+			Datasource: dsUID,
+			Queries:    []query{{RefID: "A", Datasource: dsRef{Type: dsType, UID: dsUID}, Expr: expr}},
+			// 6h (vs Grafana's 1h default) so the lab's quiet apps, which log
+			// mostly at startup, still show something when logs are first opened.
+			Range: map[string]string{"from": "now-6h", "to": "now"},
+		},
+	}
+	b, _ := json.Marshal(panes)
+	return fmt.Sprintf("http://grafana.%s/explore?orgId=1&schemaVersion=1&panes=%s", domain, url.QueryEscape(string(b)))
 }
 
 // WebSocket keepalive tuning. Pings keep idle connections alive through

--- a/src/internal/httpapi/handlers.go
+++ b/src/internal/httpapi/handlers.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -440,42 +441,109 @@ type ScenarioRef struct {
 // PlatformComponentDetail is the per-tool details payload: what it is, how it's
 // installed, and which scenarios depend on it.
 type PlatformComponentDetail struct {
-	Category        string        `json:"category"`
-	Name            string        `json:"name"`
-	Namespace       string        `json:"namespace"`
-	Installed       bool          `json:"installed"`
-	Description     string        `json:"description"`
-	Provides        []string      `json:"provides"`
-	Ports           []string      `json:"ports"`
-	Dependencies    []string      `json:"dependencies"`
-	Resources       []string      `json:"resources"`
-	Chart           string        `json:"chart"`
-	InstallCommands []string      `json:"installCommands"`
+	Category        string   `json:"category"`
+	Name            string   `json:"name"`
+	Namespace       string   `json:"namespace"`
+	Installed       bool     `json:"installed"`
+	Description     string   `json:"description"`
+	Provides        []string `json:"provides"`
+	Ports           []string `json:"ports"`
+	Dependencies    []string `json:"dependencies"`
+	Resources       []string `json:"resources"`
+	Chart           string   `json:"chart"`
+	InstallCommands []string `json:"installCommands"`
+	// InstallVars documents every shell variable that appears in the install
+	// commands — its resolved value (where the server can determine it) and what
+	// it means — so a learner can read the commands without guessing.
+	InstallVars     []InstallVar  `json:"installVars"`
 	UsedInScenarios []ScenarioRef `json:"usedInScenarios"`
 }
 
-// resolveInstallVars substitutes the shell variables an install.sh uses into
-// the commands shown on the details page, so a learner sees the real values
-// (namespace, ingress host) instead of raw $NAMESPACE / ${DOMAIN_SUFFIX}. Only
-// the variables the server can resolve are replaced; secrets and script-local
-// temp paths (e.g. $GRAFANA_ADMIN_PASSWORD, $VALUES_FILE) are left as-is —
-// they are meant to be supplied at install time, not shown.
-func resolveInstallVars(cmds []string, namespace, domain string) []string {
-	repl := []struct{ from, to string }{}
-	if namespace != "" {
-		repl = append(repl, struct{ from, to string }{"${NAMESPACE}", namespace}, struct{ from, to string }{"$NAMESPACE", namespace})
+// InstallVar is one shell variable referenced by a provider's install commands,
+// with its resolved value (empty when it is a secret/env-provided) and a short
+// explanation.
+type InstallVar struct {
+	Name        string `json:"name"`
+	Value       string `json:"value"`
+	Description string `json:"description"`
+}
+
+// shellVarRe matches a shell variable reference ($VAR or ${VAR}) in an install
+// command.
+var shellVarRe = regexp.MustCompile(`\$\{?([A-Z_][A-Z0-9_]*)\}?`)
+
+// installCommandVars resolves the deterministically-known shell variables in a
+// provider's install commands (so the shown commands read with real values, not
+// $NAMESPACE / $SCRIPT_DIR) and returns a legend documenting every variable that
+// appeared — its value where the server can determine it, and what it means —
+// so the details page can explain the commands instead of leaving raw $VARs.
+// providerDir is the provider's directory relative to the repo root.
+func installCommandVars(cmds []string, namespace, domain, providerDir string) ([]string, []InstallVar) {
+	valuesFile := ""
+	if providerDir != "" {
+		valuesFile = providerDir + "/values.yaml"
 	}
-	if domain != "" {
-		repl = append(repl, struct{ from, to string }{"${DOMAIN_SUFFIX}", domain}, struct{ from, to string }{"$DOMAIN_SUFFIX", domain})
+	// Inline substitutions: variables the server can resolve to a concrete value.
+	// Secrets and other env-provided variables are intentionally left as $VAR and
+	// only explained in the legend.
+	inline := map[string]string{
+		"NAMESPACE":     namespace,
+		"DOMAIN_SUFFIX": domain,
+		"SCRIPT_DIR":    providerDir,
+		"VALUES_FILE":   valuesFile,
 	}
-	out := make([]string, len(cmds))
+
+	resolved := make([]string, len(cmds))
 	for i, c := range cmds {
-		for _, r := range repl {
-			c = strings.ReplaceAll(c, r.from, r.to)
+		for name, val := range inline {
+			if val == "" {
+				continue
+			}
+			c = strings.ReplaceAll(c, "${"+name+"}", val)
+			c = strings.ReplaceAll(c, "$"+name, val)
 		}
-		out[i] = c
+		resolved[i] = c
 	}
-	return out
+
+	// Build the legend from the ORIGINAL commands so resolved variables are still
+	// explained. Order of first appearance, de-duplicated.
+	seen := map[string]bool{}
+	var vars []InstallVar
+	for _, c := range cmds {
+		for _, m := range shellVarRe.FindAllStringSubmatch(c, -1) {
+			vname := m[1]
+			if seen[vname] {
+				continue
+			}
+			seen[vname] = true
+			vars = append(vars, describeInstallVar(vname, inline))
+		}
+	}
+	return resolved, vars
+}
+
+// describeInstallVar returns the value/meaning of one install-command variable.
+// Known lab variables get a concrete value; recognised secret patterns are
+// flagged as env-provided; anything else is described generically.
+func describeInstallVar(name string, inline map[string]string) InstallVar {
+	switch name {
+	case "NAMESPACE":
+		return InstallVar{name, inline[name], "Kubernetes namespace this component installs into."}
+	case "DOMAIN_SUFFIX":
+		return InstallVar{name, inline[name], "Ingress domain suffix for this lab (host = <service>.<suffix>)."}
+	case "SCRIPT_DIR":
+		return InstallVar{name, inline[name], "This provider's directory, where install.sh and values.yaml live."}
+	case "VALUES_FILE":
+		return InstallVar{name, inline[name], "Helm values file the install renders and applies (a temp copy of this provider's values.yaml)."}
+	case "MONITORING_NAMESPACE":
+		return InstallVar{name, "monitoring", "Namespace of the monitoring stack (Prometheus/Grafana), used for cross-references."}
+	case "PROFILE":
+		return InstallVar{name, "", "Active runtime profile (k3d | kind | aks | eks), selected by the lab."}
+	}
+	if strings.HasSuffix(name, "_PASSWORD") || strings.HasSuffix(name, "_TOKEN") || strings.HasSuffix(name, "_KEY") {
+		return InstallVar{name, "", "Secret — export this environment variable before installing (a built-in default is used otherwise)."}
+	}
+	return InstallVar{name, "", "Environment variable read by the install script (provide it before installing to override the default)."}
 }
 
 // nonNilStrings returns s, or an empty (non-nil) slice when s is nil, so it
@@ -509,6 +577,11 @@ func (s *Server) handlePlatformComponentDetail(w http.ResponseWriter, r *http.Re
 	}
 
 	meta := p.Meta()
+	providerDir := p.Name
+	if rel, err := filepath.Rel(s.cfg.ProjectRoot, p.Path); err == nil {
+		providerDir = filepath.ToSlash(rel)
+	}
+	resolvedCmds, installVars := installCommandVars(p.InstallCommands(), p.Namespace(), s.cfg.DomainSuffix, providerDir)
 	// Guarantee non-nil slices: a Go nil slice marshals to JSON null, and the UI
 	// reads e.g. detail.provides.length — a null there crashes the details view.
 	detail := PlatformComponentDetail{
@@ -522,7 +595,8 @@ func (s *Server) handlePlatformComponentDetail(w http.ResponseWriter, r *http.Re
 		Dependencies:    nonNilStrings(meta.Dependencies),
 		Resources:       nonNilStrings(meta.Resources),
 		Chart:           meta.Chart,
-		InstallCommands: nonNilStrings(resolveInstallVars(p.InstallCommands(), p.Namespace(), s.cfg.DomainSuffix)),
+		InstallCommands: nonNilStrings(resolvedCmds),
+		InstallVars:     installVars,
 		UsedInScenarios: s.scenariosUsingComponent(category, name),
 	}
 	respondJSON(w, http.StatusOK, detail)

--- a/src/internal/httpapi/handlers.go
+++ b/src/internal/httpapi/handlers.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
+	"github.com/sagar2395/snowopslabs/internal/appdetail"
 	"github.com/sagar2395/snowopslabs/internal/config"
 	"github.com/sagar2395/snowopslabs/internal/k8s"
 	"github.com/sagar2395/snowopslabs/internal/scenario"
@@ -198,6 +199,35 @@ func (s *Server) handleListApps(w http.ResponseWriter, r *http.Request) {
 	}
 
 	respondJSON(w, http.StatusOK, result)
+}
+
+// handleAppDetail returns the "how it's built and deployed" view for one app:
+// overview, stack, and the actual Dockerfile + Helm chart with their repo paths.
+func (s *Server) handleAppDetail(w http.ResponseWriter, r *http.Request) {
+	name := mux.Vars(r)["name"]
+	if !isValidName(name) {
+		respondError(w, r, http.StatusBadRequest, "invalid_input", fmt.Sprintf("invalid app name %q: must match ^[a-zA-Z0-9_-]{1,64}$", name))
+		return
+	}
+	apps, _ := config.ListApps(s.cfg.ProjectRoot)
+	found := false
+	for _, a := range apps {
+		if a == name {
+			found = true
+			break
+		}
+	}
+	if !found {
+		respondError(w, r, http.StatusNotFound, "not_found", fmt.Sprintf("app %q not found", name))
+		return
+	}
+
+	build, deploy, namespace, valuesFile := "", "", "", ""
+	if appCfg, _ := config.LoadAppConfig(s.cfg.ProjectRoot, name); appCfg != nil {
+		build, deploy, namespace, valuesFile = appCfg.BuildStrategy, appCfg.DeployStrategy, appCfg.Namespace, appCfg.HelmValues
+	}
+	detail := appdetail.Build(s.cfg.ProjectRoot, name, build, deploy, namespace, valuesFile)
+	respondJSON(w, http.StatusOK, detail)
 }
 
 func (s *Server) handleAppDeploy(w http.ResponseWriter, r *http.Request) {

--- a/src/internal/httpapi/handlers.go
+++ b/src/internal/httpapi/handlers.go
@@ -424,6 +424,30 @@ type PlatformComponentDetail struct {
 	UsedInScenarios []ScenarioRef `json:"usedInScenarios"`
 }
 
+// resolveInstallVars substitutes the shell variables an install.sh uses into
+// the commands shown on the details page, so a learner sees the real values
+// (namespace, ingress host) instead of raw $NAMESPACE / ${DOMAIN_SUFFIX}. Only
+// the variables the server can resolve are replaced; secrets and script-local
+// temp paths (e.g. $GRAFANA_ADMIN_PASSWORD, $VALUES_FILE) are left as-is —
+// they are meant to be supplied at install time, not shown.
+func resolveInstallVars(cmds []string, namespace, domain string) []string {
+	repl := []struct{ from, to string }{}
+	if namespace != "" {
+		repl = append(repl, struct{ from, to string }{"${NAMESPACE}", namespace}, struct{ from, to string }{"$NAMESPACE", namespace})
+	}
+	if domain != "" {
+		repl = append(repl, struct{ from, to string }{"${DOMAIN_SUFFIX}", domain}, struct{ from, to string }{"$DOMAIN_SUFFIX", domain})
+	}
+	out := make([]string, len(cmds))
+	for i, c := range cmds {
+		for _, r := range repl {
+			c = strings.ReplaceAll(c, r.from, r.to)
+		}
+		out[i] = c
+	}
+	return out
+}
+
 // nonNilStrings returns s, or an empty (non-nil) slice when s is nil, so it
 // marshals to a JSON [] instead of null — the UI indexes .length on these.
 func nonNilStrings(s []string) []string {
@@ -468,7 +492,7 @@ func (s *Server) handlePlatformComponentDetail(w http.ResponseWriter, r *http.Re
 		Dependencies:    nonNilStrings(meta.Dependencies),
 		Resources:       nonNilStrings(meta.Resources),
 		Chart:           meta.Chart,
-		InstallCommands: nonNilStrings(p.InstallCommands()),
+		InstallCommands: nonNilStrings(resolveInstallVars(p.InstallCommands(), p.Namespace(), s.cfg.DomainSuffix)),
 		UsedInScenarios: s.scenariosUsingComponent(category, name),
 	}
 	respondJSON(w, http.StatusOK, detail)

--- a/src/internal/httpapi/handlers_test.go
+++ b/src/internal/httpapi/handlers_test.go
@@ -41,6 +41,31 @@ func TestIsValidName(t *testing.T) {
 	}
 }
 
+// TestPlatformComponentDetail_EmptyMarshalsAsArrays guards the platform details
+// view: the UI reads .provides.length etc., so a nil slice serialized as JSON
+// null would crash it. The handler routes empty lists through nonNilStrings (and
+// seeds usedInScenarios non-nil), so the payload must carry [] everywhere.
+func TestPlatformComponentDetail_EmptyMarshalsAsArrays(t *testing.T) {
+	detail := PlatformComponentDetail{
+		Provides:        nonNilStrings(nil),
+		Ports:           nonNilStrings(nil),
+		Dependencies:    nonNilStrings(nil),
+		Resources:       nonNilStrings(nil),
+		InstallCommands: nonNilStrings(nil),
+		UsedInScenarios: []ScenarioRef{},
+	}
+	b, err := json.Marshal(detail)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	body := string(b)
+	for _, field := range []string{"provides", "ports", "dependencies", "resources", "installCommands", "usedInScenarios"} {
+		if strings.Contains(body, `"`+field+`":null`) {
+			t.Errorf("%q marshaled as null; want []: %s", field, body)
+		}
+	}
+}
+
 // setVars injects gorilla/mux path variables into a request for handler testing.
 func setVars(r *http.Request, vars map[string]string) *http.Request {
 	return mux.SetURLVars(r, vars)

--- a/src/internal/httpapi/incident.go
+++ b/src/internal/httpapi/incident.go
@@ -43,9 +43,7 @@ func (s *Server) handleListIncidents(w http.ResponseWriter, r *http.Request) {
 	if faults == nil {
 		faults = []*incident.Fault{}
 	}
-	// The incident list is a composite (catalog + live active state), not a plain
-	// collection, so it keeps its shape on both versions; it still gains an ETag
-	// for conditional revalidation.
+
 	writeJSONCached(w, r, http.StatusOK, map[string]interface{}{
 		"faults": faults,
 		"active": active,

--- a/src/internal/httpapi/lab.go
+++ b/src/internal/httpapi/lab.go
@@ -116,11 +116,7 @@ func (s *Server) handleLabReset(w http.ResponseWriter, r *http.Request) {
 	s.exec.BroadcastStart(jobID, label)
 	go func() {
 		err := lab.Execute(plan, s.labDeps(true))
-		// Force-clear scenario and incident activation state regardless of how
-		// teardown went: after a reset their prerequisites are gone, so they must
-		// read as inactive (and be re-activatable) even if a component teardown
-		// failed part-way. The cluster resources are handled by the plan above;
-		// this only reconciles the on-disk activation markers.
+		// Force-clear scenario and incident activation state.
 		s.scenes.DeactivateAll()
 		if s.incidents != nil {
 			s.incidents.ClearActiveState()

--- a/src/internal/httpapi/lab.go
+++ b/src/internal/httpapi/lab.go
@@ -115,7 +115,17 @@ func (s *Server) handleLabReset(w http.ResponseWriter, r *http.Request) {
 	label := "Reset lab"
 	s.exec.BroadcastStart(jobID, label)
 	go func() {
-		s.exec.BroadcastEnd(jobID, label, lab.Execute(plan, s.labDeps(true)))
+		err := lab.Execute(plan, s.labDeps(true))
+		// Force-clear scenario and incident activation state regardless of how
+		// teardown went: after a reset their prerequisites are gone, so they must
+		// read as inactive (and be re-activatable) even if a component teardown
+		// failed part-way. The cluster resources are handled by the plan above;
+		// this only reconciles the on-disk activation markers.
+		s.scenes.DeactivateAll()
+		if s.incidents != nil {
+			s.incidents.ClearActiveState()
+		}
+		s.exec.BroadcastEnd(jobID, label, err)
 	}()
 	respondJSON(w, http.StatusAccepted, map[string]interface{}{
 		"jobId": jobID, "status": "accepted", "steps": len(plan),

--- a/src/internal/httpapi/learn.go
+++ b/src/internal/httpapi/learn.go
@@ -127,6 +127,18 @@ func (s *Server) handleLearnStart(w http.ResponseWriter, r *http.Request) {
 	respondJSON(w, http.StatusOK, learnProgressPayload(p, prog))
 }
 
+// handleLearnReset discards a path's progress so the learner starts over. It is
+// intentionally distinct from lab reset — progress is not cluster state.
+func (s *Server) handleLearnReset(w http.ResponseWriter, r *http.Request) {
+	name := mux.Vars(r)["name"]
+	eng := learnEngine(s)
+	if err := eng.ResetProgress(name); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	respondJSON(w, http.StatusOK, map[string]interface{}{"path": name, "started": false})
+}
+
 func (s *Server) handleLearnProgress(w http.ResponseWriter, r *http.Request) {
 	name := mux.Vars(r)["name"]
 	eng := learnEngine(s)

--- a/src/internal/httpapi/server.go
+++ b/src/internal/httpapi/server.go
@@ -45,20 +45,13 @@ type Server struct {
 	router    *mux.Router
 	upgrader  websocket.Upgrader
 	uiFS      fs.FS
-	// uiDir, when set (via WithUIDir / LABCTL_UI_DIR), serves the UI live from
-	// this directory on disk instead of the embedded bundle — so UI edits show
-	// after `npm run build` with no Go rebuild. uiSource records the resolved
-	// choice (source + bundle hash) for the startup banner.
-	uiDir    string
-	uiSource string
+	uiDir     string
+	uiSource  string
 
-	// runStore is the durable run store the run console reads (W3/W6). It is the
-	// same database labctl writes through the run engine, so the UI shows runs
-	// regardless of which process created them. Opened best-effort; nil disables
-	// the /runs endpoints (they answer 503) rather than refusing to boot.
+	// runStore is the durable run store the run console reads.
 	runStore *store.Store
 
-	// Auth (task 062). authEnabled mirrors LABCTL_AUTH at construction time;
+	// authEnabled mirrors LABCTL_AUTH at construction time;
 	// when false, the middleware is a pass-through and behaviour is unchanged.
 	authEnabled bool
 	users       *auth.Store
@@ -88,10 +81,7 @@ func WithRunStore(st *store.Store) ServerOption {
 	return func(s *Server) { s.runStore = st }
 }
 
-// WithUIDir serves the UI live from a directory on disk (via http.Dir) instead
-// of the embedded bundle. Used by `labctl ui` when LABCTL_UI_DIR / --ui-dir is
-// set, so a developer sees UI changes after `npm run build` without rebuilding
-// the binary. An empty dir leaves the embedded bundle in effect.
+// WithUIDir serves the UI live from a directory on disk (via http.Dir) instead of the embedded bundle.
 func WithUIDir(dir string) ServerOption {
 	return func(s *Server) { s.uiDir = dir }
 }
@@ -178,10 +168,7 @@ func (s *Server) httpServer(addr string) *http.Server {
 	}
 }
 
-// CheckBind refuses a network-exposed bind when authentication is off. Binding
-// anything other than loopback (including the empty host, which means all
-// interfaces) exposes cluster-control endpoints; without auth that is a footgun,
-// so the server declines to start and explains how to proceed.
+// CheckBind refuses a network-exposed bind when authentication is off.
 func CheckBind(host string, authEnabled bool) error {
 	if authEnabled || IsLoopbackHost(host) {
 		return nil
@@ -212,19 +199,9 @@ func IsLoopbackHost(host string) bool {
 func (s *Server) setupRoutes() {
 	s.router = mux.NewRouter()
 
-	// The same handler set is mounted under two prefixes: /api/v2 (the versioned
-	// surface third parties and the UI should target) and /api (the unversioned
-	// alias the current UI still uses). gorilla/mux matches in registration
-	// order, so /api/v2 — the more specific prefix — MUST be registered first;
-	// otherwise the /api subrouter would swallow /api/v2/* requests.
 	s.registerAPI(s.router.PathPrefix("/api/v2").Subrouter(), apiV2)
 	s.registerAPI(s.router.PathPrefix("/api").Subrouter(), apiV1)
 
-	// Prometheus scrape endpoint — top-level (no /api auth or JSON middleware),
-	// registered before the UI catch-all. Only present when metrics are enabled.
-	// No .Methods() restriction: the handler itself enforces GET/HEAD and
-	// answers 405 otherwise, so a POST reaches it instead of falling through to
-	// the SPA catch-all.
 	if s.metrics != nil {
 		s.router.Handle("/metrics", s.metrics.Handler())
 	}
@@ -234,9 +211,7 @@ func (s *Server) setupRoutes() {
 
 // resolveUIFS decides where the UI is served from and records a startup banner
 // (UIInfo) naming the source and the built bundle, so a stale server process is
-// obvious rather than silently serving old code. Order: an explicit on-disk
-// uiDir (dev live-reload), then the embedded bundle, then a dev-checkout dist on
-// disk (src/ui/dist — the Vite output — or a legacy ui/dist).
+// obvious rather than silently serving old code.
 func (s *Server) resolveUIFS() http.FileSystem {
 	if s.uiDir != "" {
 		s.uiSource = fmt.Sprintf("UI from disk (live): %s [%s]", s.uiDir, uiBundleName(http.Dir(s.uiDir)))
@@ -289,11 +264,7 @@ func uiBundleName(fsys http.FileSystem) string {
 }
 
 // spaHandler serves static UI assets, falling back to index.html for any path
-// that is not an existing file. The web UI is a single-page app with real
-// client-side routes (e.g. /scenarios); a deep link or a refresh must return
-// the app shell so the router can render the right view, rather than a 404 from
-// the file server. API and /metrics routes are registered before this catch-all,
-// so they are never shadowed by the fallback.
+// that is not an existing file.
 func spaHandler(fsys http.FileSystem) http.Handler {
 	fileServer := http.FileServer(fsys)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -382,10 +353,6 @@ func (s *Server) registerAPI(api *mux.Router, version string) {
 	api.HandleFunc("/results/{kind}", s.handleResultsByKind).Methods("GET", "OPTIONS")
 	api.HandleFunc("/progress", s.handleProgress).Methods("GET", "OPTIONS")
 	api.HandleFunc("/challenges", s.handleListChallenges).Methods("GET", "OPTIONS")
-	// Literal paths MUST be registered before the "/{name}" wildcard: gorilla/mux
-	// matches in registration order, so "/challenges/status" and
-	// "/challenges/history" would otherwise be swallowed by "/{name}" (name=
-	// "status"/"history") and 404 when the lookup fails.
 	api.HandleFunc("/challenges/status", s.handleChallengeStatus).Methods("GET", "OPTIONS")
 	api.HandleFunc("/challenges/history", s.handleChallengeHistory).Methods("GET", "OPTIONS")
 	api.HandleFunc("/challenges/complete", s.handleChallengeMarkComplete).Methods("POST", "OPTIONS")
@@ -402,9 +369,6 @@ func (s *Server) registerAPI(api *mux.Router, version string) {
 	api.HandleFunc("/traffic", s.handleTrafficInfo).Methods("GET", "OPTIONS")
 	api.HandleFunc("/traffic/start", s.handleTrafficStart).Methods("POST", "OPTIONS")
 	api.HandleFunc("/traffic/stop", s.handleTrafficStop).Methods("POST", "OPTIONS")
-	// Durable run history + live transcript — what the run console renders. The
-	// literal-then-wildcard ordering rule applies, but /runs/{id} and its
-	// subpaths don't collide with a literal here.
 	api.HandleFunc("/runs", s.handleRunsList).Methods("GET", "OPTIONS")
 	api.HandleFunc("/runs/{id}", s.handleRunGet).Methods("GET", "OPTIONS")
 	api.HandleFunc("/runs/{id}/logs", s.handleRunLogs).Methods("GET", "OPTIONS")
@@ -414,14 +378,9 @@ func (s *Server) registerAPI(api *mux.Router, version string) {
 	api.HandleFunc("/runtimes/{name}/deactivate", s.handleRuntimeDeactivate).Methods("POST", "OPTIONS")
 
 	api.HandleFunc("/ws", s.handleWebSocket)
-	// Server-Sent Events fallback for the same event stream, with the same
-	// ?after=<seq> cursor semantics (WebSockets are blocked by some proxies).
 	api.HandleFunc("/stream", s.handleStreamSSE).Methods("GET", "OPTIONS")
 }
 
-// originAllowed reports whether a browser-supplied Origin header is trusted:
-// no Origin (curl, CLI clients), localhost origins (Vite dev server), or an
-// origin whose host matches the request host (the embedded UI itself).
 func originAllowed(r *http.Request) bool {
 	origin := r.Header.Get("Origin")
 	if origin == "" {
@@ -455,10 +414,7 @@ func corsMiddleware(next http.Handler) http.Handler {
 			w.WriteHeader(http.StatusOK)
 			return
 		}
-		// Reject cross-site state-changing requests. Browsers always attach
-		// an Origin header to cross-origin POSTs, so a malicious website
-		// can't trigger cluster actions on localhost; CLI clients send no
-		// Origin and are unaffected.
+
 		if (r.Method == "POST" || r.Method == "DELETE") && origin != "" && !originAllowed(r) {
 			respondError(w, r, http.StatusForbidden, "forbidden_origin", "cross-origin requests are not allowed")
 			return
@@ -474,9 +430,6 @@ func jsonMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-// ErrorResponse is the legacy (v1) JSON error envelope, kept for the /api alias
-// so existing clients are unaffected. /api/v2 emits RFC 7807 problem+json
-// instead (see respondProblem).
 type ErrorResponse struct {
 	Error string `json:"error"`
 	Code  string `json:"code,omitempty"`
@@ -487,11 +440,6 @@ func respondJSON(w http.ResponseWriter, status int, data interface{}) {
 	_ = json.NewEncoder(w).Encode(data)
 }
 
-// respondError writes an error in the envelope appropriate to the request's API
-// version: RFC 7807 problem+json under /api/v2, the legacy {error,code} shape
-// under /api. code is a stable machine slug (see knownProblemSlugs); msg is the
-// human-readable detail. The version is read from the request context, so unit
-// tests that call a handler directly (no version tag) get the v1 shape.
 func respondError(w http.ResponseWriter, r *http.Request, status int, code, msg string) {
 	if apiVersionFrom(r.Context()) == apiV2 {
 		respondProblem(w, r, status, code, msg)

--- a/src/internal/httpapi/server.go
+++ b/src/internal/httpapi/server.go
@@ -5,12 +5,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/fs"
 	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
+	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -41,6 +45,12 @@ type Server struct {
 	router    *mux.Router
 	upgrader  websocket.Upgrader
 	uiFS      fs.FS
+	// uiDir, when set (via WithUIDir / LABCTL_UI_DIR), serves the UI live from
+	// this directory on disk instead of the embedded bundle — so UI edits show
+	// after `npm run build` with no Go rebuild. uiSource records the resolved
+	// choice (source + bundle hash) for the startup banner.
+	uiDir    string
+	uiSource string
 
 	// runStore is the durable run store the run console reads (W3/W6). It is the
 	// same database labctl writes through the run engine, so the UI shows runs
@@ -76,6 +86,14 @@ func WithMetrics(app *metrics.App) ServerOption {
 // best-effort when no store is provided.
 func WithRunStore(st *store.Store) ServerOption {
 	return func(s *Server) { s.runStore = st }
+}
+
+// WithUIDir serves the UI live from a directory on disk (via http.Dir) instead
+// of the embedded bundle. Used by `labctl ui` when LABCTL_UI_DIR / --ui-dir is
+// set, so a developer sees UI changes after `npm run build` without rebuilding
+// the binary. An empty dir leaves the embedded bundle in effect.
+func WithUIDir(dir string) ServerOption {
+	return func(s *Server) { s.uiDir = dir }
 }
 
 // NewServer creates a new API server. The embeddedUI parameter should be the
@@ -211,17 +229,63 @@ func (s *Server) setupRoutes() {
 		s.router.Handle("/metrics", s.metrics.Handler())
 	}
 
-	// Serve UI — use embedded FS if available, fall back to filesystem for dev.
-	var uiFS http.FileSystem
+	s.router.PathPrefix("/").Handler(spaHandler(s.resolveUIFS()))
+}
+
+// resolveUIFS decides where the UI is served from and records a startup banner
+// (UIInfo) naming the source and the built bundle, so a stale server process is
+// obvious rather than silently serving old code. Order: an explicit on-disk
+// uiDir (dev live-reload), then the embedded bundle, then a dev-checkout dist on
+// disk (src/ui/dist — the Vite output — or a legacy ui/dist).
+func (s *Server) resolveUIFS() http.FileSystem {
+	if s.uiDir != "" {
+		s.uiSource = fmt.Sprintf("UI from disk (live): %s [%s]", s.uiDir, uiBundleName(http.Dir(s.uiDir)))
+		return http.Dir(s.uiDir)
+	}
 	if s.uiFS != nil {
 		if _, err := fs.Stat(s.uiFS, "index.html"); err == nil {
-			uiFS = http.FS(s.uiFS)
+			fsys := http.FS(s.uiFS)
+			s.uiSource = fmt.Sprintf("embedded UI [%s] — rebuild with `make cli-build` to update", uiBundleName(fsys))
+			return fsys
 		}
 	}
-	if uiFS == nil {
-		uiFS = http.Dir(s.cfg.ProjectRoot + "/ui/dist")
+	// Dev checkout with no embedded bundle: serve the Vite output from disk.
+	for _, p := range []string{
+		filepath.Join(s.cfg.ProjectRoot, "src", "ui", "dist"),
+		filepath.Join(s.cfg.ProjectRoot, "ui", "dist"),
+	} {
+		if _, err := os.Stat(filepath.Join(p, "index.html")); err == nil {
+			s.uiSource = fmt.Sprintf("UI from disk: %s [%s]", p, uiBundleName(http.Dir(p)))
+			return http.Dir(p)
+		}
 	}
-	s.router.PathPrefix("/").Handler(spaHandler(uiFS))
+	fallback := filepath.Join(s.cfg.ProjectRoot, "src", "ui", "dist")
+	s.uiSource = "UI not found (no embedded bundle and no built dist) — run `make ui`"
+	return http.Dir(fallback)
+}
+
+// UIInfo returns a one-line description of the resolved UI source and its built
+// bundle hash, for `labctl ui` to print on startup.
+func (s *Server) UIInfo() string { return s.uiSource }
+
+var uiBundleRe = regexp.MustCompile(`assets/index-[A-Za-z0-9_-]+\.(?:js|css)`)
+
+// uiBundleName reads index.html and returns the hashed entry-bundle filename,
+// which changes on every UI build — the fingerprint that tells two builds apart.
+func uiBundleName(fsys http.FileSystem) string {
+	f, err := fsys.Open("index.html")
+	if err != nil {
+		return "no index.html"
+	}
+	defer f.Close()
+	b, err := io.ReadAll(io.LimitReader(f, 1<<16))
+	if err != nil {
+		return "unreadable"
+	}
+	if m := uiBundleRe.FindString(string(b)); m != "" {
+		return strings.TrimPrefix(m, "assets/")
+	}
+	return "unknown bundle"
 }
 
 // spaHandler serves static UI assets, falling back to index.html for any path
@@ -285,12 +349,14 @@ func (s *Server) registerAPI(api *mux.Router, version string) {
 	api.HandleFunc("/status", s.handleStatus).Methods("GET", "OPTIONS")
 	api.HandleFunc("/jobs", s.handleJobs).Methods("GET", "OPTIONS")
 	api.HandleFunc("/apps", s.handleListApps).Methods("GET", "OPTIONS")
+	api.HandleFunc("/apps/{name}/detail", s.handleAppDetail).Methods("GET", "OPTIONS")
 	api.HandleFunc("/apps/{name}/build", s.handleAppBuild).Methods("POST", "OPTIONS")
 	api.HandleFunc("/apps/{name}/deploy", s.handleAppDeploy).Methods("POST", "OPTIONS")
 	api.HandleFunc("/apps/{name}/destroy", s.handleAppDestroy).Methods("POST", "OPTIONS")
 	api.HandleFunc("/platform", s.handlePlatformStatus).Methods("GET", "OPTIONS")
 	api.HandleFunc("/platform/up", s.handlePlatformUp).Methods("POST", "OPTIONS")
 	api.HandleFunc("/platform/down", s.handlePlatformDown).Methods("POST", "OPTIONS")
+	api.HandleFunc("/platform/component/{category}/{name}", s.handlePlatformComponentDetail).Methods("GET", "OPTIONS")
 	api.HandleFunc("/platform/component/{category}/{name}/up", s.handleComponentUp).Methods("POST", "OPTIONS")
 	api.HandleFunc("/platform/component/{category}/{name}/down", s.handleComponentDown).Methods("POST", "OPTIONS")
 	api.HandleFunc("/dashboards", s.handleDashboardURLs).Methods("GET", "OPTIONS")

--- a/src/internal/httpapi/server.go
+++ b/src/internal/httpapi/server.go
@@ -393,6 +393,7 @@ func (s *Server) registerAPI(api *mux.Router, version string) {
 	api.HandleFunc("/learn/paths", s.handleLearnPaths).Methods("GET", "OPTIONS")
 	api.HandleFunc("/learn/paths/{name}", s.handleLearnPath).Methods("GET", "OPTIONS")
 	api.HandleFunc("/learn/paths/{name}/start", s.handleLearnStart).Methods("POST", "OPTIONS")
+	api.HandleFunc("/learn/paths/{name}/reset", s.handleLearnReset).Methods("POST", "OPTIONS")
 	api.HandleFunc("/learn/paths/{name}/progress", s.handleLearnProgress).Methods("GET", "OPTIONS")
 	api.HandleFunc("/learn/paths/{name}/complete", s.handleLearnMarkComplete).Methods("POST", "OPTIONS")
 	api.HandleFunc("/services", s.handleListServices).Methods("GET", "OPTIONS")

--- a/src/internal/incident/incident.go
+++ b/src/internal/incident/incident.go
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
-// Package incident implements the fault library engine (tasks 045/046):
+// Package incident implements the fault library engine:
 // discovery and validation of incidents/<name>/ fault definitions, injection
 // and resolution through their scripts, and resolution detection via the
-// shared checks primitive. Faults are declarative content — this package
-// never encodes fault logic in Go (golden rules 2 and 9).
+// shared checks primitive.
 package incident
 
 import (
@@ -43,12 +42,12 @@ type Fault struct {
 	Target        Target        `yaml:"target" json:"target"`
 	Prerequisites Prerequisites `yaml:"prerequisites" json:"prerequisites"`
 	Detection     checks.Check  `yaml:"detection" json:"detection"` // passes ⇔ the fault is RESOLVED
-	// ExpectAlert names the Alertmanager alert this fault should fire (task
-	// 049). inject.sh arms the matching PrometheusRule from alerts/rule.yaml;
+	// ExpectAlert names the Alertmanager alert this fault should fire
+	// inject.sh arms the matching PrometheusRule from alerts/rule.yaml;
 	// `incident status` reports whether the page went out.
 	ExpectAlert string `yaml:"expectAlert,omitempty" json:"expectAlert,omitempty"`
 
-	// References and Snippets (M2) present upstream docs and applyable manifest
+	// References and Snippets present upstream docs and applyable manifest
 	// fragments to whoever is working the incident. They reuse the shared SDK
 	// types so scenarios and incidents display them identically.
 	References []scenario.Reference `yaml:"references,omitempty" json:"references,omitempty"`
@@ -280,10 +279,6 @@ func (e *Engine) clearActive() {
 	_ = os.Remove(e.activeFile())
 }
 
-// ClearActiveState removes the active-incident marker without running fault
-// restoration. Lab reset uses it so a torn-down incident (whose target app or
-// component no longer exists) does not linger as active. Returns the fault name
-// that was cleared, or "" if none was active.
 func (e *Engine) ClearActiveState() string {
 	a, _ := e.Active()
 	e.clearActive()
@@ -295,9 +290,7 @@ func (e *Engine) ClearActiveState() string {
 
 // --- operations ----------------------------------------------------------------
 
-// Preflight checks a fault's prerequisites before injection. Exported so the
-// durable inject path (which submits inject.sh through the run engine) can gate
-// itself with exactly the checks Inject applies.
+// Preflight checks a fault's prerequisites before injection.
 func (e *Engine) Preflight(f *Fault) error { return e.preflight(f) }
 
 // MarkInjected records a fault as the active incident. The durable inject path

--- a/src/internal/incident/incident.go
+++ b/src/internal/incident/incident.go
@@ -280,6 +280,19 @@ func (e *Engine) clearActive() {
 	_ = os.Remove(e.activeFile())
 }
 
+// ClearActiveState removes the active-incident marker without running fault
+// restoration. Lab reset uses it so a torn-down incident (whose target app or
+// component no longer exists) does not linger as active. Returns the fault name
+// that was cleared, or "" if none was active.
+func (e *Engine) ClearActiveState() string {
+	a, _ := e.Active()
+	e.clearActive()
+	if a == nil {
+		return ""
+	}
+	return a.Fault
+}
+
 // --- operations ----------------------------------------------------------------
 
 // Preflight checks a fault's prerequisites before injection. Exported so the

--- a/src/internal/k8s/client.go
+++ b/src/internal/k8s/client.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -38,6 +40,25 @@ type AppStatus struct {
 	Available string    `json:"available"`
 	Pods      []PodInfo `json:"pods"`
 	Deployed  bool      `json:"deployed"`
+}
+
+// HPAStatus holds the live autoscaler state for a Deployment — replica counts,
+// bounds, and the driving metric vs its target — the same info `kubectl get hpa`
+// prints, structured for the UI. Present is false when no HPA targets the
+// Deployment (KEDA-created HPAs count; KEDA renders a normal HPA underneath).
+type HPAStatus struct {
+	Present         bool   `json:"present"`
+	Name            string `json:"name"`
+	MinReplicas     int    `json:"minReplicas"`
+	MaxReplicas     int    `json:"maxReplicas"`
+	CurrentReplicas int    `json:"currentReplicas"`
+	DesiredReplicas int    `json:"desiredReplicas"`
+	// The scaling trigger: an External metric for KEDA/Prometheus, a Resource
+	// metric (cpu/memory) for a classic HPA. Current/Target are pre-rendered
+	// strings, e.g. "27467m / 25" or "27% / 80%".
+	MetricName    string `json:"metricName,omitempty"`
+	MetricCurrent string `json:"metricCurrent,omitempty"`
+	MetricTarget  string `json:"metricTarget,omitempty"`
 }
 
 // GetClusterInfo returns current cluster information.
@@ -169,6 +190,159 @@ func GetAppStatus(ctx context.Context, appName, namespace string) (*AppStatus, e
 	}
 
 	return status, nil
+}
+
+// GetHPAStatus returns the HPA state for a Deployment, or Present=false when
+// none targets it. "No HPA" is never an error — it just means "not autoscaled".
+func GetHPAStatus(ctx context.Context, namespace, deploymentName string) (*HPAStatus, error) {
+	out, err := kubectl(ctx, "get", "hpa", "-n", namespace, "-o", "json")
+	if err != nil {
+		// A missing namespace or no HPA resource is not an error for the caller;
+		// it simply means the app is not autoscaled.
+		return &HPAStatus{Present: false}, nil //nolint:nilerr
+	}
+	return parseHPAList(out, deploymentName)
+}
+
+// hpaMetricValue is the subset of a v2 HPA metric target/current we render.
+type hpaMetricValue struct {
+	AverageValue       string `json:"averageValue"`
+	Value              string `json:"value"`
+	AverageUtilization *int   `json:"averageUtilization"`
+}
+
+type hpaMetric struct {
+	Type     string `json:"type"`
+	External *struct {
+		Metric  struct{ Name string } `json:"metric"`
+		Target  hpaMetricValue        `json:"target"`
+		Current hpaMetricValue        `json:"current"`
+	} `json:"external"`
+	Resource *struct {
+		Name    string         `json:"name"`
+		Target  hpaMetricValue `json:"target"`
+		Current hpaMetricValue `json:"current"`
+	} `json:"resource"`
+}
+
+// parseHPAList finds the HPA whose scaleTargetRef points at deploymentName and
+// returns its structured status. Kept as a pure function (no kubectl) so it can
+// be unit-tested with fixture JSON.
+func parseHPAList(raw, deploymentName string) (*HPAStatus, error) {
+	var list struct {
+		Items []struct {
+			Metadata struct{ Name string } `json:"metadata"`
+			Spec     struct {
+				ScaleTargetRef struct {
+					Kind string `json:"kind"`
+					Name string `json:"name"`
+				} `json:"scaleTargetRef"`
+				MinReplicas *int        `json:"minReplicas"`
+				MaxReplicas int         `json:"maxReplicas"`
+				Metrics     []hpaMetric `json:"metrics"`
+			} `json:"spec"`
+			Status struct {
+				CurrentReplicas int         `json:"currentReplicas"`
+				DesiredReplicas int         `json:"desiredReplicas"`
+				CurrentMetrics  []hpaMetric `json:"currentMetrics"`
+			} `json:"status"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal([]byte(raw), &list); err != nil {
+		return nil, fmt.Errorf("parsing hpa list: %w", err)
+	}
+
+	for _, it := range list.Items {
+		if it.Spec.ScaleTargetRef.Name != deploymentName {
+			continue
+		}
+		hpa := &HPAStatus{
+			Present:         true,
+			Name:            it.Metadata.Name,
+			MaxReplicas:     it.Spec.MaxReplicas,
+			CurrentReplicas: it.Status.CurrentReplicas,
+			DesiredReplicas: it.Status.DesiredReplicas,
+		}
+		if it.Spec.MinReplicas != nil {
+			hpa.MinReplicas = *it.Spec.MinReplicas
+		} else {
+			hpa.MinReplicas = 1 // HPA default when unset
+		}
+		if len(it.Spec.Metrics) > 0 {
+			name, target := metricNameAndValue(it.Spec.Metrics[0], true)
+			hpa.MetricName = name
+			hpa.MetricTarget = target
+		}
+		if len(it.Status.CurrentMetrics) > 0 {
+			_, current := metricNameAndValue(it.Status.CurrentMetrics[0], false)
+			hpa.MetricCurrent = current
+		}
+		return hpa, nil
+	}
+	return &HPAStatus{Present: false}, nil
+}
+
+// metricNameAndValue extracts a v2 HPA metric's name and rendered value —
+// target when target is true, else current. Handles External (KEDA/Prometheus)
+// and Resource (cpu/memory) metrics, the two kinds this lab produces. Values are
+// humanized (300m → 0.3) and KEDA's "s0-" scaler prefix is stripped from names.
+func metricNameAndValue(m hpaMetric, target bool) (name, value string) {
+	pick := func(v hpaMetricValue, suffix string) string {
+		switch {
+		case v.AverageValue != "":
+			return humanizeQuantity(v.AverageValue)
+		case v.Value != "":
+			return humanizeQuantity(v.Value)
+		case v.AverageUtilization != nil:
+			return fmt.Sprintf("%d%s", *v.AverageUtilization, suffix)
+		}
+		return ""
+	}
+	switch {
+	case m.External != nil:
+		name = cleanMetricName(m.External.Metric.Name)
+		if target {
+			value = pick(m.External.Target, "")
+		} else {
+			value = pick(m.External.Current, "")
+		}
+	case m.Resource != nil:
+		name = m.Resource.Name
+		if target {
+			value = pick(m.Resource.Target, "%")
+		} else {
+			value = pick(m.Resource.Current, "%")
+		}
+	}
+	return name, value
+}
+
+// kedaScalerPrefix matches the "s0-"/"s1-" scaler-index prefix KEDA prepends to
+// the external metric names it registers, optionally followed by the scaler-type
+// word (e.g. "s0-prometheus-go_api_requests_per_second" or "s0-kafka-lag").
+var kedaScalerPrefix = regexp.MustCompile(`^s\d+-(?:prometheus|kafka|cron|cpu|memory)-`)
+
+// cleanMetricName strips KEDA's scaler prefix so the UI shows the raw metric a
+// learner declared, not KEDA's internal registration name. The bare "s0-" form
+// (no scaler-type word) is stripped too.
+func cleanMetricName(name string) string {
+	if cleaned := kedaScalerPrefix.ReplaceAllString(name, ""); cleaned != name {
+		return cleaned
+	}
+	return regexp.MustCompile(`^s\d+-`).ReplaceAllString(name, "")
+}
+
+// humanizeQuantity renders a Kubernetes quantity as a plain decimal. HPA metric
+// values below 1 come back in milli notation ("300m" = 0.3), which is opaque to
+// most users; this converts the common milli and plain-integer cases and leaves
+// anything else (binary suffixes, unusual units) untouched.
+func humanizeQuantity(q string) string {
+	if strings.HasSuffix(q, "m") {
+		if n, err := strconv.ParseInt(strings.TrimSuffix(q, "m"), 10, 64); err == nil {
+			return strconv.FormatFloat(float64(n)/1000, 'f', -1, 64)
+		}
+	}
+	return q
 }
 
 // NamespaceExists checks if a namespace exists.

--- a/src/internal/k8s/client_test.go
+++ b/src/internal/k8s/client_test.go
@@ -163,3 +163,155 @@ func TestParsePodList_MultiContainerRestarts(t *testing.T) {
 		t.Errorf("Restarts: got %q, want %q", p.Restarts, "5")
 	}
 }
+
+// kedaHPAJSON is a KEDA-created v2 HPA driven by an External (Prometheus) metric
+// — the shape the autoscaling-under-load scenario produces under load.
+const kedaHPAJSON = `{
+  "items": [
+    {
+      "metadata": {"name": "keda-hpa-go-api"},
+      "spec": {
+        "scaleTargetRef": {"kind": "Deployment", "name": "go-api"},
+        "minReplicas": 1,
+        "maxReplicas": 6,
+        "metrics": [
+          {"type": "External", "external": {
+            "metric": {"name": "s0-prometheus-go_api_requests_per_second"},
+            "target": {"type": "AverageValue", "averageValue": "25"}
+          }}
+        ]
+      },
+      "status": {
+        "currentReplicas": 3,
+        "desiredReplicas": 3,
+        "currentMetrics": [
+          {"type": "External", "external": {
+            "metric": {"name": "s0-prometheus-go_api_requests_per_second"},
+            "current": {"averageValue": "27467m"}
+          }}
+        ]
+      }
+    }
+  ]
+}`
+
+// cpuHPAJSON is a classic Resource (CPU utilization) HPA targeting a different
+// deployment, used to prove selection-by-name and the "%" rendering.
+const cpuHPAJSON = `{
+  "items": [
+    {
+      "metadata": {"name": "web-hpa"},
+      "spec": {
+        "scaleTargetRef": {"kind": "Deployment", "name": "web"},
+        "minReplicas": 2,
+        "maxReplicas": 10,
+        "metrics": [
+          {"type": "Resource", "resource": {"name": "cpu", "target": {"type": "Utilization", "averageUtilization": 80}}}
+        ]
+      },
+      "status": {
+        "currentReplicas": 4,
+        "desiredReplicas": 5,
+        "currentMetrics": [
+          {"type": "Resource", "resource": {"name": "cpu", "current": {"averageUtilization": 92}}}
+        ]
+      }
+    }
+  ]
+}`
+
+func TestParseHPAList_KEDAExternalMetric(t *testing.T) {
+	hpa, err := parseHPAList(kedaHPAJSON, "go-api")
+	if err != nil {
+		t.Fatalf("parseHPAList: %v", err)
+	}
+	if !hpa.Present {
+		t.Fatal("expected HPA to be present for go-api")
+	}
+	if hpa.MinReplicas != 1 || hpa.MaxReplicas != 6 {
+		t.Errorf("bounds: got %d/%d, want 1/6", hpa.MinReplicas, hpa.MaxReplicas)
+	}
+	if hpa.CurrentReplicas != 3 || hpa.DesiredReplicas != 3 {
+		t.Errorf("replicas: got current=%d desired=%d, want 3/3", hpa.CurrentReplicas, hpa.DesiredReplicas)
+	}
+	if hpa.MetricName != "go_api_requests_per_second" {
+		t.Errorf("name: got %q, want %q (KEDA prefix must be stripped)", hpa.MetricName, "go_api_requests_per_second")
+	}
+	if hpa.MetricTarget != "25" {
+		t.Errorf("target: got %q, want %q", hpa.MetricTarget, "25")
+	}
+	// 27467m (milli) must be humanized to a plain decimal.
+	if hpa.MetricCurrent != "27.467" {
+		t.Errorf("current: got %q, want %q", hpa.MetricCurrent, "27.467")
+	}
+}
+
+func TestCleanMetricName(t *testing.T) {
+	cases := map[string]string{
+		"s0-prometheus-go_api_requests_per_second": "go_api_requests_per_second",
+		"s0-go_api_requests_per_second":            "go_api_requests_per_second",
+		"s1-kafka-lag":                             "lag",
+		"go_api_requests_per_second":               "go_api_requests_per_second",
+		"cpu":                                      "cpu",
+	}
+	for in, want := range cases {
+		if got := cleanMetricName(in); got != want {
+			t.Errorf("cleanMetricName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestHumanizeQuantity(t *testing.T) {
+	cases := map[string]string{
+		"300m":   "0.3",
+		"27467m": "27.467",
+		"1000m":  "1",
+		"25":     "25",
+		"80%":    "80%", // not a quantity — left as-is
+		"":       "",
+	}
+	for in, want := range cases {
+		if got := humanizeQuantity(in); got != want {
+			t.Errorf("humanizeQuantity(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestParseHPAList_CPUResourceMetricRendersPercent(t *testing.T) {
+	hpa, err := parseHPAList(cpuHPAJSON, "web")
+	if err != nil {
+		t.Fatalf("parseHPAList: %v", err)
+	}
+	if hpa.MetricName != "cpu" {
+		t.Errorf("name: got %q, want %q", hpa.MetricName, "cpu")
+	}
+	if hpa.MetricTarget != "80%" {
+		t.Errorf("target: got %q, want %q", hpa.MetricTarget, "80%")
+	}
+	if hpa.MetricCurrent != "92%" {
+		t.Errorf("current: got %q, want %q", hpa.MetricCurrent, "92%")
+	}
+	if hpa.DesiredReplicas != 5 {
+		t.Errorf("desired: got %d, want 5", hpa.DesiredReplicas)
+	}
+}
+
+func TestParseHPAList_NoMatchingDeployment(t *testing.T) {
+	hpa, err := parseHPAList(kedaHPAJSON, "some-other-app")
+	if err != nil {
+		t.Fatalf("parseHPAList: %v", err)
+	}
+	if hpa.Present {
+		t.Error("expected Present=false when no HPA targets the deployment")
+	}
+}
+
+func TestParseHPAList_EmptyList(t *testing.T) {
+	hpa, err := parseHPAList(`{"items": []}`, "go-api")
+	if err != nil {
+		t.Fatalf("parseHPAList: %v", err)
+	}
+	if hpa.Present {
+		t.Error("expected Present=false for an empty HPA list")
+	}
+}

--- a/src/internal/learn/learn.go
+++ b/src/internal/learn/learn.go
@@ -222,6 +222,21 @@ func (e *Engine) StartPath(name string) (*Progress, error) {
 	return prog, e.saveProgress(prog)
 }
 
+// ResetProgress discards a path's progress record so it reads as not-started
+// and the learner can begin again from the first module. This is deliberately
+// separate from lab reset: tearing down the cluster must not wipe what someone
+// has learned, and clearing progress must not touch the cluster. A path that was
+// never started is a no-op (no error).
+func (e *Engine) ResetProgress(name string) error {
+	if _, err := e.LoadPath(name); err != nil {
+		return err
+	}
+	if err := os.Remove(e.progressFile(name)); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
 // MarkComplete records module at idx as complete.
 func (e *Engine) MarkComplete(prog *Progress, idx int) error {
 	return e.markComplete(prog, idx, "", "")

--- a/src/internal/learn/learn.go
+++ b/src/internal/learn/learn.go
@@ -18,10 +18,7 @@ type Check struct {
 	Name string `yaml:"name"`
 	Type string `yaml:"type"` // http | kubectl | promql | script
 	URL  string `yaml:"url,omitempty"`
-	// ExpectStatus is the canonical expected HTTP status. ExpectedStatus is a
-	// deprecated alias kept so external learning-path content authored against
-	// the old field keeps loading; new content should use expectStatus (see
-	// sdk/schemas/check.schema.json). Prefer Status() over reading either field.
+	// ExpectStatus is the canonical expected HTTP status.
 	ExpectStatus   int    `yaml:"expectStatus,omitempty"`
 	ExpectedStatus int    `yaml:"expectedStatus,omitempty"`
 	Command        string `yaml:"command,omitempty"`
@@ -223,10 +220,7 @@ func (e *Engine) StartPath(name string) (*Progress, error) {
 }
 
 // ResetProgress discards a path's progress record so it reads as not-started
-// and the learner can begin again from the first module. This is deliberately
-// separate from lab reset: tearing down the cluster must not wipe what someone
-// has learned, and clearing progress must not touch the cluster. A path that was
-// never started is a no-op (no error).
+// and the learner can begin again from the first module.
 func (e *Engine) ResetProgress(name string) error {
 	if _, err := e.LoadPath(name); err != nil {
 		return err

--- a/src/internal/learn/reset_test.go
+++ b/src/internal/learn/reset_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+package learn
+
+import (
+	"os"
+	"testing"
+)
+
+func TestResetProgress(t *testing.T) {
+	e, learnDir := makeEngine(t)
+	writePathYAML(t, learnDir, "test-path", validPathYAML)
+
+	// Start and complete a module, then reset.
+	prog, err := e.StartPath("test-path")
+	if err != nil {
+		t.Fatalf("StartPath: %v", err)
+	}
+	if err := e.MarkComplete(prog, 0); err != nil {
+		t.Fatalf("MarkComplete: %v", err)
+	}
+	if _, err := os.Stat(e.progressFile("test-path")); err != nil {
+		t.Fatalf("progress file should exist after start: %v", err)
+	}
+
+	if err := e.ResetProgress("test-path"); err != nil {
+		t.Fatalf("ResetProgress: %v", err)
+	}
+	// Progress must read as not-started again.
+	got, err := e.Progress("test-path")
+	if err != nil {
+		t.Fatalf("Progress after reset: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil (not-started) progress after reset, got %+v", got)
+	}
+}
+
+func TestResetProgress_NeverStarted_NoError(t *testing.T) {
+	e, learnDir := makeEngine(t)
+	writePathYAML(t, learnDir, "test-path", validPathYAML)
+	if err := e.ResetProgress("test-path"); err != nil {
+		t.Errorf("resetting a never-started path should be a no-op, got %v", err)
+	}
+}
+
+func TestResetProgress_UnknownPath_Errors(t *testing.T) {
+	e, _ := makeEngine(t)
+	if err := e.ResetProgress("does-not-exist"); err == nil {
+		t.Error("expected an error resetting an unknown path")
+	}
+}

--- a/src/internal/platform/detail.go
+++ b/src/internal/platform/detail.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+package platform
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// InterfaceMeta is the subset of a provider's _interface.yaml the details page
+// surfaces: what the tool is, what it offers, and what it needs.
+type InterfaceMeta struct {
+	Description  string   `json:"description"`
+	Provides     []string `json:"provides"`
+	Ports        []string `json:"ports"`
+	Dependencies []string `json:"dependencies"`
+	Resources    []string `json:"resources"`
+	Chart        string   `json:"chart"`
+}
+
+// rawInterface mirrors the _interface.yaml fields we read. Providers declare it
+// either in their own directory or one level up at the category root, so this is
+// tried against both.
+type rawInterface struct {
+	Description string   `yaml:"description"`
+	Provides    []string `yaml:"provides"`
+	Requires    struct {
+		KubernetesResources []string `yaml:"kubernetes_resources"`
+		Ports               []string `yaml:"ports"`
+		Dependencies        []string `yaml:"dependencies"`
+	} `yaml:"requires"`
+	Implementations map[string]struct {
+		Chart string `yaml:"chart"`
+	} `yaml:"implementations"`
+}
+
+// Meta reads and parses the provider's _interface.yaml. It looks in the
+// provider's own directory first, then the category directory above it (some
+// categories describe all their providers in one shared file). A missing or
+// unparseable file yields a zero InterfaceMeta, never an error — the details
+// page degrades gracefully.
+func (p *Provider) Meta() InterfaceMeta {
+	for _, path := range []string{
+		filepath.Join(p.Path, "_interface.yaml"),
+		filepath.Join(filepath.Dir(p.Path), "_interface.yaml"),
+	} {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var raw rawInterface
+		if yaml.Unmarshal(data, &raw) != nil {
+			continue
+		}
+		meta := InterfaceMeta{
+			Description:  strings.TrimSpace(raw.Description),
+			Provides:     raw.Provides,
+			Ports:        raw.Requires.Ports,
+			Dependencies: raw.Requires.Dependencies,
+			Resources:    raw.Requires.KubernetesResources,
+		}
+		if impl, ok := raw.Implementations[p.Name]; ok {
+			meta.Chart = impl.Chart
+		}
+		return meta
+	}
+	return InterfaceMeta{}
+}
+
+// InstallCommands extracts the helm/kubectl commands from the provider's
+// install.sh so the details page shows how the tool actually reaches the
+// cluster. Backslash line-continuations are joined into one command, and shell
+// plumbing (repo adds, waits, variables) is left out — only the install verbs a
+// learner would recognise are returned.
+func (p *Provider) InstallCommands() []string {
+	f, err := os.Open(filepath.Join(p.Path, "install.sh"))
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	var cmds []string
+	var cont strings.Builder
+	joining := false
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := sc.Text()
+		trimmed := strings.TrimSpace(line)
+		if joining {
+			cont.WriteString(" " + trimmed)
+		} else if isInstallVerb(trimmed) {
+			cont.Reset()
+			cont.WriteString(trimmed)
+		} else {
+			continue
+		}
+		if strings.HasSuffix(trimmed, "\\") {
+			// Drop the trailing backslash and keep accumulating.
+			s := strings.TrimSpace(strings.TrimSuffix(cont.String(), "\\"))
+			cont.Reset()
+			cont.WriteString(s)
+			joining = true
+			continue
+		}
+		joining = false
+		cmds = append(cmds, normalizeSpaces(cont.String()))
+	}
+	return cmds
+}
+
+// isInstallVerb reports whether a line begins a helm/kubectl install command
+// (the ones worth showing), as opposed to repo setup, waits, or status reads.
+func isInstallVerb(line string) bool {
+	switch {
+	case strings.HasPrefix(line, "helm upgrade"), strings.HasPrefix(line, "helm install"):
+		return true
+	case strings.HasPrefix(line, "kubectl apply"), strings.HasPrefix(line, "kubectl create"):
+		return true
+	}
+	return false
+}
+
+// normalizeSpaces collapses runs of whitespace (left by joining continuations)
+// into single spaces.
+func normalizeSpaces(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}

--- a/src/internal/platform/detail.go
+++ b/src/internal/platform/detail.go
@@ -80,7 +80,7 @@ func (p *Provider) InstallCommands() []string {
 	if err != nil {
 		return nil
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	var cmds []string
 	var cont strings.Builder

--- a/src/internal/platform/detail_test.go
+++ b/src/internal/platform/detail_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+package platform
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestProviderMeta_ReadsOwnInterface(t *testing.T) {
+	dir := t.TempDir()
+	provDir := filepath.Join(dir, "monitoring", "grafana")
+	if err := os.MkdirAll(provDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	iface := `
+description: Dashboard and visualization platform for observability data.
+provides:
+  - Web-based dashboard interface
+  - Data source integration
+requires:
+  kubernetes_resources:
+    - Namespace (monitoring)
+  ports:
+    - 80 (HTTP web interface)
+  dependencies:
+    - monitoring/metrics
+implementations:
+  grafana:
+    chart: grafana/grafana
+`
+	if err := os.WriteFile(filepath.Join(provDir, "_interface.yaml"), []byte(iface), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	p := Provider{Category: "monitoring", Name: "grafana", Path: provDir}
+	meta := p.Meta()
+	if meta.Description == "" || meta.Chart != "grafana/grafana" {
+		t.Fatalf("meta not parsed: %+v", meta)
+	}
+	if len(meta.Provides) != 2 || len(meta.Ports) != 1 || len(meta.Dependencies) != 1 {
+		t.Errorf("meta lists wrong: %+v", meta)
+	}
+}
+
+// When a provider has no _interface.yaml of its own, Meta falls back to the
+// category directory above it (where some categories describe all providers).
+func TestProviderMeta_FallsBackToCategoryDir(t *testing.T) {
+	dir := t.TempDir()
+	catDir := filepath.Join(dir, "ingress")
+	provDir := filepath.Join(catDir, "traefik")
+	if err := os.MkdirAll(provDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(catDir, "_interface.yaml"), []byte("description: Ingress controller.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	p := Provider{Category: "ingress", Name: "traefik", Path: provDir}
+	if got := p.Meta().Description; got != "Ingress controller." {
+		t.Errorf("fallback description = %q", got)
+	}
+}
+
+func TestProviderInstallCommands_ExtractsHelmAndJoinsContinuations(t *testing.T) {
+	dir := t.TempDir()
+	script := `#!/usr/bin/env bash
+set -euo pipefail
+helm repo add grafana https://grafana.github.io/helm-charts
+helm repo update
+helm upgrade --install loki grafana/loki \
+  --namespace "$NAMESPACE" \
+  --create-namespace \
+  -f values.yaml
+kubectl rollout status statefulset/loki -n "$NAMESPACE"
+kubectl apply -f extra.yaml
+`
+	if err := os.WriteFile(filepath.Join(dir, "install.sh"), []byte(script), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	p := Provider{Name: "loki", Path: dir}
+	cmds := p.InstallCommands()
+	if len(cmds) != 2 {
+		t.Fatalf("expected 2 install commands (helm upgrade + kubectl apply), got %d: %v", len(cmds), cmds)
+	}
+	if cmds[0] != `helm upgrade --install loki grafana/loki --namespace "$NAMESPACE" --create-namespace -f values.yaml` {
+		t.Errorf("continuation not joined cleanly: %q", cmds[0])
+	}
+	if cmds[1] != "kubectl apply -f extra.yaml" {
+		t.Errorf("kubectl apply not captured: %q", cmds[1])
+	}
+}

--- a/src/internal/scenario/engine.go
+++ b/src/internal/scenario/engine.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
+	"strconv"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -46,6 +48,8 @@ type (
 	Explore        = schema.Explore
 	ExploreURL     = schema.ExploreURL
 	ExploreCommand = schema.ExploreCommand
+	Parameter      = schema.Parameter
+	Snippet        = schema.Snippet
 )
 
 // Engine discovers, loads, and manages scenarios.
@@ -69,7 +73,18 @@ type Engine struct {
 	// points it at the run's transcript so activation output is recorded and
 	// streamed through the run engine rather than racing on os.Stdout.
 	out io.Writer
+
+	// activationParams: raw user overrides for the next Up (set via
+	// SetActivationParams, cleared after). resolvedParams: the effective values
+	// (defaults overlaid with overrides) that resolveTemplate substitutes for
+	// {{.ParamName}} during that Up. Both follow the SetOutput serialisation rule.
+	activationParams map[string]string
+	resolvedParams   map[string]string
 }
+
+// SetActivationParams stages parameter overrides for the next Up (nil clears).
+// Like SetOutput, callers must serialise per engine.
+func (e *Engine) SetActivationParams(params map[string]string) { e.activationParams = params }
 
 // SetOutput redirects the progress output of Up/Down. Not safe to call while an
 // activation is in flight on the same engine; callers serialise per engine.
@@ -220,6 +235,15 @@ func (e *Engine) Up(name string, exec CommandExecutor, force bool) error {
 		return err
 	}
 
+	// Validate parameter overrides before installing anything, so a bad value
+	// (out of range, or minReplicas > maxReplicas) fails up front.
+	params, err := e.effectiveParams(s)
+	if err != nil {
+		return err
+	}
+	e.resolvedParams = params
+	defer func() { e.resolvedParams = nil }()
+
 	fmt.Fprintf(e.output(), "Activating scenario: %s\n", s.DisplayName)
 	fmt.Fprintf(e.output(), "  %s\n\n", s.Description)
 
@@ -227,6 +251,20 @@ func (e *Engine) Up(name string, exec CommandExecutor, force bool) error {
 		fmt.Fprintln(e.output(), "Objectives:")
 		for _, o := range s.Objectives {
 			fmt.Fprintf(e.output(), "  - %s\n", o)
+		}
+		fmt.Fprintln(e.output())
+	}
+
+	// Echo the effective parameter values (marking any the user overrode) so the
+	// activation transcript records exactly what was applied.
+	if len(s.Parameters) > 0 {
+		fmt.Fprintln(e.output(), "Parameters:")
+		for _, p := range s.Parameters {
+			marker := ""
+			if _, overridden := e.activationParams[p.Name]; overridden {
+				marker = "  (overridden)"
+			}
+			fmt.Fprintf(e.output(), "  - %s = %s%s\n", p.Name, params[p.Name], marker)
 		}
 		fmt.Fprintln(e.output())
 	}
@@ -371,6 +409,27 @@ func (e *Engine) Status() []ScenarioStatus {
 		})
 	}
 	return result
+}
+
+// DeactivateAll clears every active-scenario marker without running teardown,
+// and returns the names it cleared. Lab reset uses this: after a reset the
+// scenarios' prerequisites are gone, so they must read as inactive (and be
+// re-activatable) even when their normal component teardown could not complete.
+func (e *Engine) DeactivateAll() []string {
+	entries, err := os.ReadDir(e.stateDir)
+	if err != nil {
+		return nil
+	}
+	var cleared []string
+	for _, en := range entries {
+		if en.IsDir() || !strings.HasSuffix(en.Name(), ".active") {
+			continue
+		}
+		name := strings.TrimSuffix(en.Name(), ".active")
+		e.markInactive(name)
+		cleared = append(cleared, name)
+	}
+	return cleared
 }
 
 // ScenarioStatus is a lightweight status for listing scenarios.
@@ -629,10 +688,10 @@ func (e *Engine) installGrafanaDashboard(s *Scenario, comp *Component, exec Comm
 		return fmt.Errorf("reading dashboard dir: %w", err)
 	}
 
-	ns := comp.Namespace
-	if ns == "" {
-		ns = e.MonitoringNamespace
-	}
+	// Template the namespace like every other installer. Using the raw
+	// comp.Namespace shipped a literal "{{.MonitoringNamespace}}" that kubectl
+	// rejected — and the error was swallowed, so Up wrongly reported success.
+	ns := e.componentNamespace(comp, e.MonitoringNamespace)
 
 	for _, entry := range entries {
 		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
@@ -641,7 +700,7 @@ func (e *Engine) installGrafanaDashboard(s *Scenario, comp *Component, exec Comm
 
 		data, err := os.ReadFile(filepath.Join(dashDir, entry.Name()))
 		if err != nil {
-			continue
+			return fmt.Errorf("reading dashboard %s: %w", entry.Name(), err)
 		}
 
 		cmName := fmt.Sprintf("scenario-%s-%s", s.Name, strings.TrimSuffix(entry.Name(), ".json"))
@@ -661,10 +720,15 @@ data:
 
 		tmpPath, cleanup, err := writeTempManifest(cm)
 		if err != nil {
-			continue
+			return fmt.Errorf("writing dashboard manifest %s: %w", entry.Name(), err)
 		}
-		_, _ = exec.RunCommandStreamed("Apply dashboard "+entry.Name(), "kubectl", "apply", "-f", tmpPath)
+		// Propagate apply failures instead of discarding them, so a broken
+		// dashboard surfaces as a failed activation rather than a false success.
+		_, err = exec.RunCommandStreamed("Apply dashboard "+entry.Name(), "kubectl", "apply", "-f", tmpPath)
 		cleanup()
+		if err != nil {
+			return fmt.Errorf("applying dashboard %s: %w", entry.Name(), err)
+		}
 	}
 
 	return nil
@@ -677,10 +741,9 @@ func (e *Engine) uninstallGrafanaDashboard(s *Scenario, comp *Component, exec Co
 		return nil //nolint:nilerr // no dashboard dir means nothing to delete — uninstall is a no-op
 	}
 
-	ns := comp.Namespace
-	if ns == "" {
-		ns = e.MonitoringNamespace
-	}
+	// Template the namespace as install does, or delete hits the wrong namespace
+	// and the ConfigMap leaks while `scenario down` reports success.
+	ns := e.componentNamespace(comp, e.MonitoringNamespace)
 
 	for _, entry := range entries {
 		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
@@ -758,7 +821,74 @@ func (e *Engine) ResolveTemplate(input string) string {
 // verbatim and the apply failed.
 var labctlVar = regexp.MustCompile(`{{\s*\.(\w+)\s*}}`)
 
+// effectiveParams resolves each declared parameter to its default or user
+// override, validated for type, bounds, and NotGreaterThan. An unknown override
+// key is an error so a typo'd name fails loudly instead of being ignored.
+func (e *Engine) effectiveParams(s *Scenario) (map[string]string, error) {
+	declared := make(map[string]Parameter, len(s.Parameters))
+	for _, p := range s.Parameters {
+		declared[p.Name] = p
+	}
+	for k := range e.activationParams {
+		if _, ok := declared[k]; !ok {
+			names := make([]string, 0, len(s.Parameters))
+			for _, p := range s.Parameters {
+				names = append(names, p.Name)
+			}
+			sort.Strings(names)
+			if len(names) == 0 {
+				return nil, fmt.Errorf("scenario %q accepts no parameters", s.Name)
+			}
+			return nil, fmt.Errorf("unknown parameter %q (scenario %q accepts: %s)", k, s.Name, strings.Join(names, ", "))
+		}
+	}
+
+	values := make(map[string]string, len(s.Parameters))
+	ints := make(map[string]int, len(s.Parameters))
+	for _, p := range s.Parameters {
+		val, label := p.Default, "default"
+		if ov, ok := e.activationParams[p.Name]; ok {
+			val, label = strings.TrimSpace(ov), "override"
+		}
+		if err := p.ValidateValue(val, label); err != nil {
+			return nil, err
+		}
+		values[p.Name] = val
+		if p.IsInt() {
+			n, _ := strconv.Atoi(val) // safe: ValidateValue parsed it
+			ints[p.Name] = n
+		}
+	}
+
+	// Relational constraints, e.g. minReplicas ≤ maxReplicas.
+	for _, p := range s.Parameters {
+		if p.NotGreaterThan == "" {
+			continue
+		}
+		if this, ok1 := ints[p.Name]; ok1 {
+			if other, ok2 := ints[p.NotGreaterThan]; ok2 && this > other {
+				return nil, fmt.Errorf("parameter %q (%d) must not be greater than %q (%d)", p.Name, this, p.NotGreaterThan, other)
+			}
+		}
+	}
+	return values, nil
+}
+
 func (e *Engine) resolveTemplate(input string) string {
+	return e.resolveTemplateWith(input, nil)
+}
+
+// ResolveTemplateWithParams resolves template vars using the given parameter
+// values on top of the engine's built-ins. Used to render a scenario's snippets
+// and explore hints with parameter defaults so {{.Param}} shows a real value.
+func (e *Engine) ResolveTemplateWithParams(input string, params map[string]string) string {
+	return e.resolveTemplateWith(input, params)
+}
+
+// resolveTemplateWith substitutes {{.Var}} placeholders. Precedence: built-ins,
+// then the active activation's resolvedParams, then extra — so a parameter can
+// never shadow a built-in, and live activation values win over display defaults.
+func (e *Engine) resolveTemplateWith(input string, extra map[string]string) string {
 	data := map[string]string{
 		"DomainSuffix":        e.DomainSuffix,
 		"ProjectRoot":         e.ProjectRoot,
@@ -766,6 +896,15 @@ func (e *Engine) resolveTemplate(input string) string {
 		"LokiRetentionPeriod": lokiRetentionPeriod(),
 		"IngressClass":        ingressClassOr(e.IngressClass),
 	}
+	overlay := func(src map[string]string) {
+		for k, v := range src {
+			if _, taken := data[k]; !taken {
+				data[k] = v
+			}
+		}
+	}
+	overlay(e.resolvedParams)
+	overlay(extra)
 	return labctlVar.ReplaceAllStringFunc(input, func(match string) string {
 		key := labctlVar.FindStringSubmatch(match)[1]
 		if v, ok := data[key]; ok {
@@ -773,6 +912,62 @@ func (e *Engine) resolveTemplate(input string) string {
 		}
 		return match // unknown {{.Var}} — leave it for whoever else consumes it
 	})
+}
+
+// ParamDefaults maps each declared parameter to its default value, or nil when
+// the scenario declares none.
+func (e *Engine) ParamDefaults(s *Scenario) map[string]string {
+	if len(s.Parameters) == 0 {
+		return nil
+	}
+	m := make(map[string]string, len(s.Parameters))
+	for _, p := range s.Parameters {
+		m[p.Name] = p.Default
+	}
+	return m
+}
+
+// SnippetContent returns a snippet's display text — its inline YAML or the
+// contents of its Path file — template-resolved with the scenario's parameter
+// defaults so {{.Param}} placeholders show real values. Path reads are confined
+// to the scenario directory. A file's leading comment banner is stripped so the
+// UI shows clean code (the banner's explanation belongs in the snippet's
+// description); inline comments on individual fields are kept.
+func (e *Engine) SnippetContent(s *Scenario, sn Snippet) (string, error) {
+	defaults := e.ParamDefaults(s)
+	if sn.YAML != "" {
+		return e.resolveTemplateWith(sn.YAML, defaults), nil
+	}
+	if sn.Path == "" {
+		return "", nil
+	}
+	full := filepath.Join(s.Dir, filepath.Clean(sn.Path))
+	if !strings.HasPrefix(full, filepath.Clean(s.Dir)+string(os.PathSeparator)) {
+		return "", fmt.Errorf("snippet path %q escapes the scenario directory", sn.Path)
+	}
+	data, err := os.ReadFile(full)
+	if err != nil {
+		return "", err
+	}
+	return e.resolveTemplateWith(stripLeadingCommentBanner(string(data)), defaults), nil
+}
+
+// stripLeadingCommentBanner drops a manifest's leading block of "#" comment and
+// blank lines — the header that documents the file for repo readers — so the
+// snippet shown in the UI starts at the first real line of config. Inline
+// comments further down (e.g. after a YAML field) are untouched.
+func stripLeadingCommentBanner(src string) string {
+	lines := strings.Split(src, "\n")
+	i := 0
+	for i < len(lines) {
+		trimmed := strings.TrimSpace(lines[i])
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			i++
+			continue
+		}
+		break
+	}
+	return strings.Join(lines[i:], "\n")
 }
 
 // ingressClassOr falls back to traefik (the k3d default) when no class is set,

--- a/src/internal/scenario/install_test.go
+++ b/src/internal/scenario/install_test.go
@@ -2,6 +2,7 @@
 package scenario
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -107,6 +108,86 @@ func TestHelm_InstallAndUninstallUseSameResolvedNamespace(t *testing.T) {
 
 // namespaceOf reads the --namespace value from a recorded helm call.
 func (e *Engine) namespaceOf(call []string) string { return flagValue(call, "--namespace") }
+
+// failingExec returns an error from every RunCommandStreamed call, simulating a
+// kubectl apply that the cluster rejects.
+type failingExec struct{ recordingExec }
+
+func (f *failingExec) RunCommandStreamed(label, name string, args ...string) (string, error) {
+	_, _ = f.recordingExec.RunCommandStreamed(label, name, args...)
+	return "", fmt.Errorf("kubectl apply rejected the manifest")
+}
+
+// installGrafanaDashboard must resolve the namespace template like the other
+// installers (a raw "{{.MonitoringNamespace}}" produced an invalid ConfigMap
+// that kubectl rejected), and uninstall must target the same resolved namespace
+// so `scenario down` deletes what `up` created.
+func TestGrafanaDashboard_InstallAndUninstallUseSameResolvedNamespace(t *testing.T) {
+	eng := newTestEngine(t)
+	dir := t.TempDir()
+	dashDir := filepath.Join(dir, "dashboards")
+	if err := os.MkdirAll(dashDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dashDir, "autoscaling.json"), []byte(`{"title":"Autoscaling"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s := &Scenario{Name: "autoscaling-under-load", Dir: dir}
+	comp := &Component{
+		Name:      "autoscaling-dashboard",
+		Type:      "grafana-dashboard",
+		Path:      "dashboards",
+		Namespace: "{{.MonitoringNamespace}}",
+	}
+
+	install := &recordingExec{}
+	if err := eng.installGrafanaDashboard(s, comp, install); err != nil {
+		t.Fatalf("installGrafanaDashboard: %v", err)
+	}
+	apply := install.find("kubectl", "apply")
+	if apply == nil {
+		t.Fatalf("expected a kubectl apply call, got %v", install.calls)
+	}
+	out := install.files[flagValue(apply, "-f")]
+	if strings.Contains(out, "{{.MonitoringNamespace}}") {
+		t.Errorf("raw template leaked into ConfigMap:\n%s", out)
+	}
+	if !strings.Contains(out, "namespace: observability") {
+		t.Errorf("namespace not resolved to observability:\n%s", out)
+	}
+
+	uninstall := &recordingExec{}
+	if err := eng.uninstallGrafanaDashboard(s, comp, uninstall); err != nil {
+		t.Fatalf("uninstallGrafanaDashboard: %v", err)
+	}
+	del := uninstall.find("kubectl", "delete")
+	if del == nil {
+		t.Fatalf("expected a kubectl delete call, got %v", uninstall.calls)
+	}
+	if got := flagValue(del, "--namespace"); got != "observability" {
+		t.Errorf("uninstall namespace = %q, want %q (raw template must not leak)", got, "observability")
+	}
+}
+
+// A dashboard apply that the cluster rejects must fail the activation, not be
+// silently swallowed — the false-success bug the audit flagged as P0.
+func TestGrafanaDashboard_ApplyFailurePropagates(t *testing.T) {
+	eng := newTestEngine(t)
+	dir := t.TempDir()
+	dashDir := filepath.Join(dir, "dashboards")
+	if err := os.MkdirAll(dashDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dashDir, "autoscaling.json"), []byte(`{"title":"Autoscaling"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s := &Scenario{Name: "autoscaling-under-load", Dir: dir}
+	comp := &Component{Name: "autoscaling-dashboard", Type: "grafana-dashboard", Path: "dashboards"}
+
+	if err := eng.installGrafanaDashboard(s, comp, &failingExec{}); err == nil {
+		t.Fatal("expected installGrafanaDashboard to return the apply error, got nil")
+	}
+}
 
 // installManifest must render labctl's own template vars before applying, while
 // leaving foreign templating (Prometheus/Grafana) untouched.

--- a/src/internal/scenario/parameters_test.go
+++ b/src/internal/scenario/parameters_test.go
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+package scenario
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func ip(n int) *int { return &n }
+
+// paramScenario returns a scenario with the autoscaling knobs (min/max/threshold).
+func paramScenario() *Scenario {
+	return &Scenario{
+		Name: "autoscaling-under-load",
+		Parameters: []Parameter{
+			{Name: "MinReplicas", Default: "1", Type: "int", Min: ip(1), Max: ip(10), NotGreaterThan: "MaxReplicas"},
+			{Name: "MaxReplicas", Default: "6", Type: "int", Min: ip(1), Max: ip(10)},
+			{Name: "Threshold", Default: "25", Type: "int", Min: ip(1), Max: ip(500)},
+		},
+	}
+}
+
+func TestEffectiveParams_DefaultsWhenNoOverrides(t *testing.T) {
+	eng := newTestEngine(t)
+	got, err := eng.effectiveParams(paramScenario())
+	if err != nil {
+		t.Fatalf("effectiveParams: %v", err)
+	}
+	for k, want := range map[string]string{"MinReplicas": "1", "MaxReplicas": "6", "Threshold": "25"} {
+		if got[k] != want {
+			t.Errorf("%s = %q, want %q", k, got[k], want)
+		}
+	}
+}
+
+func TestEffectiveParams_AppliesValidOverrides(t *testing.T) {
+	eng := newTestEngine(t)
+	eng.SetActivationParams(map[string]string{"Threshold": "10", "MaxReplicas": "4"})
+	got, err := eng.effectiveParams(paramScenario())
+	if err != nil {
+		t.Fatalf("effectiveParams: %v", err)
+	}
+	if got["Threshold"] != "10" || got["MaxReplicas"] != "4" || got["MinReplicas"] != "1" {
+		t.Errorf("unexpected effective params: %v", got)
+	}
+}
+
+func TestEffectiveParams_RejectsBadOverrides(t *testing.T) {
+	cases := []struct {
+		name     string
+		override map[string]string
+		want     string
+	}{
+		{"above max", map[string]string{"Threshold": "9999"}, "above the maximum"},
+		{"below min", map[string]string{"MinReplicas": "0"}, "below the minimum"},
+		{"not int", map[string]string{"Threshold": "abc"}, "not an integer"},
+		{"min > max", map[string]string{"MinReplicas": "5", "MaxReplicas": "2"}, "must not be greater than"},
+		{"unknown key", map[string]string{"Bogus": "1"}, "unknown parameter"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			eng := newTestEngine(t)
+			eng.SetActivationParams(tc.override)
+			_, err := eng.effectiveParams(paramScenario())
+			if err == nil {
+				t.Fatalf("expected an error for %v", tc.override)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error = %q, want it to contain %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+// The resolved parameter values must substitute into a manifest's {{.Name}}
+// placeholders, while built-in vars still win and are never shadowed.
+func TestResolveTemplate_SubstitutesParams(t *testing.T) {
+	eng := newTestEngine(t) // monitoring namespace "observability"
+	eng.resolvedParams = map[string]string{"MinReplicas": "1", "MaxReplicas": "4", "Threshold": "10"}
+	out := eng.resolveTemplate("min={{.MinReplicas}} max={{.MaxReplicas}} thr={{.Threshold}} ns={{.MonitoringNamespace}}")
+	if out != "min=1 max=4 thr=10 ns=observability" {
+		t.Errorf("unexpected render: %q", out)
+	}
+
+	// A parameter must never shadow a built-in.
+	eng.resolvedParams = map[string]string{"MonitoringNamespace": "hijacked"}
+	if out := eng.resolveTemplate("ns={{.MonitoringNamespace}}"); out != "ns=observability" {
+		t.Errorf("param shadowed a built-in: %q", out)
+	}
+}
+
+// SnippetContent reads a snippet's Path file and resolves both parameter
+// defaults and built-in template vars, so the UI shows the real manifest.
+func TestSnippetContent_ResolvesPathWithDefaults(t *testing.T) {
+	eng := newTestEngine(t) // monitoring namespace "observability"
+	dir := t.TempDir()
+	manifest := "threshold: {{.Threshold}}\nns: {{.MonitoringNamespace}}\n"
+	if err := os.WriteFile(filepath.Join(dir, "scaledobject.yaml"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s := &Scenario{Name: "x", Dir: dir, Parameters: []Parameter{{Name: "Threshold", Default: "25", Type: "int"}}}
+
+	got, err := eng.SnippetContent(s, Snippet{Path: "scaledobject.yaml"})
+	if err != nil {
+		t.Fatalf("SnippetContent: %v", err)
+	}
+	if !strings.Contains(got, "threshold: 25") {
+		t.Errorf("parameter default not resolved:\n%s", got)
+	}
+	if !strings.Contains(got, "ns: observability") {
+		t.Errorf("built-in not resolved:\n%s", got)
+	}
+}
+
+func TestSnippetContent_InlineYAML(t *testing.T) {
+	eng := newTestEngine(t)
+	s := &Scenario{Name: "x", Parameters: []Parameter{{Name: "Threshold", Default: "25", Type: "int"}}}
+	got, err := eng.SnippetContent(s, Snippet{YAML: "t: {{.Threshold}}"})
+	if err != nil {
+		t.Fatalf("SnippetContent: %v", err)
+	}
+	if got != "t: 25" {
+		t.Errorf("inline yaml = %q, want %q", got, "t: 25")
+	}
+}
+
+// A file's leading comment banner is stripped from the snippet (it belongs in
+// the snippet description), but inline field comments are kept.
+func TestSnippetContent_StripsLeadingCommentBanner(t *testing.T) {
+	eng := newTestEngine(t)
+	dir := t.TempDir()
+	manifest := "# banner line one\n# banner line two\n\napiVersion: v1\nkind: ConfigMap  # inline stays\n"
+	if err := os.WriteFile(filepath.Join(dir, "cm.yaml"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s := &Scenario{Name: "x", Dir: dir}
+	got, err := eng.SnippetContent(s, Snippet{Path: "cm.yaml"})
+	if err != nil {
+		t.Fatalf("SnippetContent: %v", err)
+	}
+	if strings.Contains(got, "banner line") {
+		t.Errorf("leading comment banner not stripped:\n%s", got)
+	}
+	if !strings.HasPrefix(got, "apiVersion: v1") {
+		t.Errorf("snippet should start at the first real line, got:\n%s", got)
+	}
+	if !strings.Contains(got, "# inline stays") {
+		t.Errorf("inline comment was wrongly stripped:\n%s", got)
+	}
+}
+
+func TestSnippetContent_RejectsPathEscape(t *testing.T) {
+	eng := newTestEngine(t)
+	s := &Scenario{Name: "x", Dir: t.TempDir()}
+	if _, err := eng.SnippetContent(s, Snippet{Path: "../../../etc/passwd"}); err == nil {
+		t.Fatal("expected an error for a path escaping the scenario dir")
+	}
+}

--- a/src/internal/scenario/reset_test.go
+++ b/src/internal/scenario/reset_test.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+package scenario
+
+import (
+	"testing"
+)
+
+func TestDeactivateAll_ClearsMarkers(t *testing.T) {
+	e := NewEngine(t.TempDir(), "k3d.local", "k3d")
+
+	for _, n := range []string{"autoscaling-under-load", "observability-sre"} {
+		if err := e.markActive(n); err != nil {
+			t.Fatalf("markActive(%s): %v", n, err)
+		}
+	}
+	if !e.isActive("autoscaling-under-load") || !e.isActive("observability-sre") {
+		t.Fatal("precondition: both scenarios should be active")
+	}
+
+	cleared := e.DeactivateAll()
+	if len(cleared) != 2 {
+		t.Errorf("DeactivateAll cleared %d markers, want 2 (%v)", len(cleared), cleared)
+	}
+	if e.isActive("autoscaling-under-load") || e.isActive("observability-sre") {
+		t.Error("scenarios should read as inactive after DeactivateAll")
+	}
+}
+
+func TestDeactivateAll_NoMarkers_NoError(t *testing.T) {
+	e := NewEngine(t.TempDir(), "k3d.local", "k3d")
+	if cleared := e.DeactivateAll(); len(cleared) != 0 {
+		t.Errorf("expected nothing cleared on a fresh engine, got %v", cleared)
+	}
+}

--- a/src/internal/service/scenario/scenario.go
+++ b/src/internal/service/scenario/scenario.go
@@ -81,6 +81,12 @@ func New(engine *run.Engine, st *store.Store, scenes *scn.Engine, runner toolcha
 // records each in the component inventory. A concurrent op on the same scenario
 // is refused with *run.LockConflictError.
 func (s *Service) Activate(ctx context.Context, name string, force bool) (string, error) {
+	return s.ActivateWithParams(ctx, name, force, nil)
+}
+
+// ActivateWithParams is Activate with scenario parameter overrides, staged on
+// the engine for this run only. A nil/empty map behaves exactly like Activate.
+func (s *Service) ActivateWithParams(ctx context.Context, name string, force bool, params map[string]string) (string, error) {
 	sc, err := s.lookup(name)
 	if err != nil {
 		return "", err
@@ -93,6 +99,9 @@ func (s *Service) Activate(ctx context.Context, name string, force bool) (string
 			// than racing on os.Stdout.
 			s.scenes.SetOutput(out)
 			defer s.scenes.SetOutput(nil)
+			// Stage the parameter overrides for exactly this activation.
+			s.scenes.SetActivationParams(params)
+			defer s.scenes.SetActivationParams(nil)
 			exec := s.newExec(fctx, out)
 			if err := s.scenes.Up(name, exec, force); err != nil {
 				return err

--- a/src/make/cli.mk
+++ b/src/make/cli.mk
@@ -35,6 +35,10 @@ ui-build: ui-deps
 cli-build: ui-build
 	@echo "==> Embedding UI assets"
 	@mkdir -p $(CLI_UI_DEST)
+	@# Clear the previous bundle first so old hashed assets don't accumulate in
+	@# the embed dir (and the binary) build over build.
+	@rm -rf $(CLI_UI_DEST)/assets
+	@find $(CLI_UI_DEST) -maxdepth 1 -type f ! -name '.gitkeep' -delete 2>/dev/null || true
 	@cp -R $(CLI_UI_SRC)/. $(CLI_UI_DEST)/
 	@echo "==> Building labctl $(VERSION) for $$(go env GOOS)/$$(go env GOARCH)"
 	@mkdir -p $(BIN_DIR)
@@ -44,6 +48,8 @@ cli-build: ui-build
 ## cli-build-all: cross-compile every release target into dist/
 cli-build-all: ui-build
 	@mkdir -p $(CLI_UI_DEST) dist
+	@rm -rf $(CLI_UI_DEST)/assets
+	@find $(CLI_UI_DEST) -maxdepth 1 -type f ! -name '.gitkeep' -delete 2>/dev/null || true
 	@cp -R $(CLI_UI_SRC)/. $(CLI_UI_DEST)/
 	@for target in $(CLI_TARGETS); do \
 	  goos=$${target%/*}; goarch=$${target#*/}; \

--- a/src/pkg/scenario/parameters_test.go
+++ b/src/pkg/scenario/parameters_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+package scenario
+
+import (
+	"strings"
+	"testing"
+)
+
+func intp(n int) *int { return &n }
+
+func TestValidateParameters_AcceptsWellFormed(t *testing.T) {
+	params := []Parameter{
+		{Name: "MinReplicas", Default: "1", Type: "int", Min: intp(1), Max: intp(10), NotGreaterThan: "MaxReplicas"},
+		{Name: "MaxReplicas", Default: "6", Type: "int", Min: intp(1), Max: intp(10)},
+		{Name: "Threshold", Default: "25", Type: "int", Min: intp(1)},
+		{Name: "Note", Default: "hello"}, // string param, no bounds
+	}
+	if errs := ValidateParameters(params); len(errs) != 0 {
+		t.Fatalf("expected no errors, got: %v", errs)
+	}
+}
+
+func TestValidateParameters_RejectsBadDeclarations(t *testing.T) {
+	cases := []struct {
+		name   string
+		params []Parameter
+		want   string
+	}{
+		{"missing name", []Parameter{{Default: "1"}}, "name is required"},
+		{"bad template name", []Parameter{{Name: "has-dash", Default: "1"}}, "template var"},
+		{"duplicate name", []Parameter{{Name: "X", Default: "1"}, {Name: "X", Default: "2"}}, "duplicate"},
+		{"unknown type", []Parameter{{Name: "X", Default: "1", Type: "float"}}, "unknown type"},
+		{"missing default", []Parameter{{Name: "X", Type: "int"}}, "default is required"},
+		{"default out of bounds", []Parameter{{Name: "X", Default: "99", Type: "int", Max: intp(10)}}, "above the maximum"},
+		{"default not int", []Parameter{{Name: "X", Default: "abc", Type: "int"}}, "not an integer"},
+		{"notGreaterThan unknown", []Parameter{{Name: "X", Default: "1", Type: "int", NotGreaterThan: "Ghost"}}, "references unknown parameter"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := strings.Join(ValidateParameters(tc.params), "\n")
+			if !strings.Contains(errs, tc.want) {
+				t.Errorf("expected an error containing %q, got: %q", tc.want, errs)
+			}
+		})
+	}
+}
+
+func TestParameter_ValidateValue(t *testing.T) {
+	p := Parameter{Name: "Threshold", Type: "int", Min: intp(1), Max: intp(500)}
+	if err := p.ValidateValue("25", "override"); err != nil {
+		t.Errorf("25 should be valid: %v", err)
+	}
+	if err := p.ValidateValue("0", "override"); err == nil {
+		t.Error("0 is below min, should fail")
+	}
+	if err := p.ValidateValue("9999", "override"); err == nil {
+		t.Error("9999 is above max, should fail")
+	}
+	if err := p.ValidateValue("abc", "override"); err == nil {
+		t.Error("non-integer should fail")
+	}
+	// A string parameter accepts anything.
+	s := Parameter{Name: "Note", Type: "string"}
+	if err := s.ValidateValue("anything at all", "override"); err != nil {
+		t.Errorf("string param should accept any value: %v", err)
+	}
+}

--- a/src/pkg/scenario/schema.go
+++ b/src/pkg/scenario/schema.go
@@ -10,6 +10,8 @@ package scenario
 import (
 	"fmt"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/sagar2395/snowopslabs/pkg/checks"
@@ -81,6 +83,12 @@ type Scenario struct {
 	// `kubectl apply -f -` while working the exercise.
 	References []Reference `yaml:"references,omitempty" json:"references,omitempty"`
 	Snippets   []Snippet   `yaml:"snippets,omitempty" json:"snippets,omitempty"`
+
+	// Parameters are tunable knobs exposed at activation time (e.g. an
+	// autoscaler's min/max replicas and threshold), substituted into the
+	// scenario's manifests as {{.Name}} template vars. No parameters, or no
+	// overrides, means unchanged behaviour.
+	Parameters []Parameter `yaml:"parameters,omitempty" json:"parameters,omitempty"`
 
 	// Runtime fields (not from YAML)
 	Dir    string `yaml:"-" json:"-"`
@@ -154,6 +162,96 @@ type Snippet struct {
 	YAML        string `yaml:"yaml,omitempty" json:"yaml,omitempty"`
 	Path        string `yaml:"path,omitempty" json:"path,omitempty"`
 }
+
+// Parameter is a user-tunable knob exposed at activation time. Its value is
+// substituted into the scenario's manifests as a {{.Name}} template variable.
+// Name must be a Go-template-safe identifier (letters/digits/underscore) so it
+// matches the engine's {{.Name}} placeholder.
+type Parameter struct {
+	Name        string `yaml:"name" json:"name"`
+	DisplayName string `yaml:"displayName,omitempty" json:"displayName,omitempty"`
+	Description string `yaml:"description,omitempty" json:"description,omitempty"`
+	// Default is used when the user overrides nothing. Required.
+	Default string `yaml:"default" json:"default"`
+	// Type is "int" or "string" (default "string"). An int parameter is bounds-
+	// checked against Min/Max and parsed before substitution.
+	Type string `yaml:"type,omitempty" json:"type,omitempty"`
+	// Min/Max are inclusive bounds for an int parameter (ignored for strings).
+	Min *int `yaml:"min,omitempty" json:"min,omitempty"`
+	Max *int `yaml:"max,omitempty" json:"max,omitempty"`
+	// NotGreaterThan names another int parameter this one must not exceed
+	// (e.g. minReplicas ≤ maxReplicas), enforced against the effective values.
+	NotGreaterThan string `yaml:"notGreaterThan,omitempty" json:"notGreaterThan,omitempty"`
+}
+
+// IsInt reports whether the parameter is an integer parameter.
+func (p Parameter) IsInt() bool { return p.Type == "int" }
+
+// ValidateValue checks a value against the parameter's type and (for ints) its
+// Min/Max bounds. label names the value's origin in messages ("default" or
+// "override").
+func (p Parameter) ValidateValue(raw, label string) error {
+	if !p.IsInt() {
+		return nil // string parameters accept any value
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil {
+		return fmt.Errorf("parameter %q %s %q is not an integer", p.Name, label, raw)
+	}
+	if p.Min != nil && n < *p.Min {
+		return fmt.Errorf("parameter %q %s %d is below the minimum %d", p.Name, label, n, *p.Min)
+	}
+	if p.Max != nil && n > *p.Max {
+		return fmt.Errorf("parameter %q %s %d is above the maximum %d", p.Name, label, n, *p.Max)
+	}
+	return nil
+}
+
+var validParamTypes = map[string]bool{"": true, "string": true, "int": true}
+
+// ValidateParameters reports every structural problem in a parameter list: each
+// needs a template-safe name, unique across the list; a type from the allowed
+// set; a Default that satisfies its own type/bounds; and any NotGreaterThan must
+// reference another declared int parameter.
+func ValidateParameters(params []Parameter) []string {
+	var errs []string
+	names := map[string]bool{}
+	for i, p := range params {
+		where := fmt.Sprintf("parameter %d", i+1)
+		if p.Name != "" {
+			where = fmt.Sprintf("parameter %q", p.Name)
+		}
+		if strings.TrimSpace(p.Name) == "" {
+			errs = append(errs, fmt.Sprintf("%s: name is required", where))
+		} else if !templateIdent.MatchString(p.Name) {
+			errs = append(errs, fmt.Sprintf("%s: name must be letters, digits or underscore (used as a {{.Name}} template var)", where))
+		} else if names[p.Name] {
+			errs = append(errs, fmt.Sprintf("%s: duplicate parameter name", where))
+		}
+		names[p.Name] = true
+		if !validParamTypes[p.Type] {
+			errs = append(errs, fmt.Sprintf("%s: unknown type %q (expected int or string)", where, p.Type))
+		}
+		if strings.TrimSpace(p.Default) == "" {
+			errs = append(errs, fmt.Sprintf("%s: default is required", where))
+		} else if err := p.ValidateValue(p.Default, "default"); err != nil {
+			errs = append(errs, err.Error())
+		}
+	}
+	// NotGreaterThan references are checked after all names are known.
+	for _, p := range params {
+		if p.NotGreaterThan == "" {
+			continue
+		}
+		if !names[p.NotGreaterThan] {
+			errs = append(errs, fmt.Sprintf("parameter %q: notGreaterThan references unknown parameter %q", p.Name, p.NotGreaterThan))
+		}
+	}
+	return errs
+}
+
+// templateIdent matches a parameter name usable as a {{.Name}} template var.
+var templateIdent = regexp.MustCompile(`^\w+$`)
 
 // ValidateReferences reports every structural problem in a reference list. The
 // where prefix (e.g. "reference") names the field in messages so both scenarios
@@ -324,6 +422,7 @@ func (s *Scenario) Validate() error {
 
 	errs = append(errs, ValidateReferences(s.References)...)
 	errs = append(errs, ValidateSnippets(s.Snippets)...)
+	errs = append(errs, ValidateParameters(s.Parameters)...)
 
 	if len(errs) > 0 {
 		name := s.Name

--- a/src/test/shell/app_deploy_image_import.bats
+++ b/src/test/shell/app_deploy_image_import.bats
@@ -1,0 +1,70 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: Apache-2.0
+#
+# `app deploy` must ensure a docker-built image is present inside a local
+# cluster runtime (k3d/kind) before deploying. Without this, a deploy after a
+# cluster re-create — which wipes previously-imported images — leaves the pod
+# stuck in ImagePullBackOff trying to pull the never-published image from a
+# registry. These tests pin the import behaviour per runtime.
+
+load 'helpers/stub'
+
+setup() {
+  stub_setup
+  stub_command docker k3d kind helm kubectl
+  ROOT="$(project_root)"
+  DEPLOY="$ROOT/src/engine/deploy.sh"
+
+  # Minimal content root: deploy.sh resolves apps/<name>/app.env from the CWD.
+  CONTENT="$STUB_DIR/content"
+  mkdir -p "$CONTENT/apps/testapp/deploy/helm"
+  cat >"$CONTENT/apps/testapp/app.env" <<'EOF'
+APP_NAME=testapp
+BUILD_STRATEGY=docker
+DEPLOY_STRATEGY=helm
+HELM_RELEASE_NAME=testapp
+HELM_VALUES=values.yaml
+EOF
+  : >"$CONTENT/apps/testapp/deploy/helm/values.yaml"
+  cd "$CONTENT"
+}
+
+teardown() {
+  stub_teardown
+}
+
+@test "k3d deploy imports the image when it is present in the local daemon" {
+  PROFILE=k3d CLUSTER_NAME=snowops run bash "$DEPLOY" deploy testapp
+  [ "$status" -eq 0 ]
+  assert_called k3d "image import"
+  assert_called k3d "testapp:latest"
+  assert_called k3d "snowops"
+}
+
+@test "k3d deploy builds the image first when it is missing locally" {
+  # Make only `docker image inspect` fail, so the guard falls back to a build.
+  stub_when docker "inspect" 1
+  PROFILE=k3d CLUSTER_NAME=snowops run bash "$DEPLOY" deploy testapp
+  [ "$status" -eq 0 ]
+  assert_called docker "build"
+}
+
+@test "kind deploy loads the image into the named kind cluster" {
+  PROFILE=kind CLUSTER_NAME=snowops run bash "$DEPLOY" deploy testapp
+  [ "$status" -eq 0 ]
+  assert_called kind "load docker-image"
+  assert_called kind "testapp:latest"
+}
+
+@test "incluster deploy does not import or load (registry-backed)" {
+  PROFILE=incluster run bash "$DEPLOY" deploy testapp
+  [ "$status" -eq 0 ]
+  refute_called k3d "image import"
+  refute_called kind "load docker-image"
+}
+
+@test "destroy never imports an image" {
+  PROFILE=k3d run bash "$DEPLOY" destroy testapp
+  [ "$status" -eq 0 ]
+  refute_called k3d "image import"
+}

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -476,8 +476,8 @@ function RunsRoute() {
   return <Runs notify={notify} />
 }
 function LearnRoute() {
-  const { notify } = useApp()
-  return <Learn notify={notify} />
+  const { notify, requestConfirm } = useApp()
+  return <Learn notify={notify} requestConfirm={requestConfirm} />
 }
 function ChallengesRoute() {
   const { notify, requestConfirm } = useApp()

--- a/src/ui/src/api/client.ts
+++ b/src/ui/src/api/client.ts
@@ -102,6 +102,9 @@ export const api = {
   getPlatform:   ()                          => req<PlatformProvidersMap>('/platform'),
   platformUp:    ()                          => post('/platform/up'),
   platformDown:  ()                          => post('/platform/down'),
+  // Tears the lab back to post-init (deactivates scenarios/incidents, destroys
+  // apps, uninstalls non-baseline platform). Destructive → confirm=true required.
+  resetLab:      ()                          => post('/lab/reset?confirm=true'),
   componentUp:   (cat: string, name: string) => post(`/platform/component/${enc(catSegment(cat))}/${enc(name)}/up`),
   componentDown: (cat: string, name: string) => post(`/platform/component/${enc(catSegment(cat))}/${enc(name)}/down`),
   getComponent:  (cat: string, name: string) => req<PlatformComponentDetail>(`/platform/component/${enc(catSegment(cat))}/${enc(name)}`),
@@ -126,6 +129,7 @@ export const api = {
   getLearnPath:    (name: string) => req<LearnPath>(`/learn/paths/${enc(name)}`),
   getLearnProgress:(name: string) => req<LearnProgress>(`/learn/paths/${enc(name)}/progress`),
   startLearnPath:  (name: string) => req<LearnProgress>(`/learn/paths/${enc(name)}/start`, { method: 'POST' }, POST_TIMEOUT_MS),
+  resetLearnPath:  (name: string) => req<LearnProgress>(`/learn/paths/${enc(name)}/reset`, { method: 'POST' }, POST_TIMEOUT_MS),
   completeLearnModule: (name: string, moduleIdx: number) =>
     req<LearnProgress>(`/learn/paths/${enc(name)}/complete`, {
       method: 'POST',

--- a/src/ui/src/api/client.ts
+++ b/src/ui/src/api/client.ts
@@ -1,9 +1,12 @@
 import type {
   StatusResponse,
   AppInfo,
+  AppDetail,
   PlatformProvidersMap,
+  PlatformComponentDetail,
   DashboardURL,
   Scenario,
+  ScenarioVerifyResult,
   Runtime,
   ActionAccepted,
   JobInfo,
@@ -68,8 +71,13 @@ async function req<T>(path: string, opts?: RequestInit, timeoutMs = GET_TIMEOUT_
   }
 }
 
-function post(path: string) {
-  return req<ActionAccepted>(path, { method: 'POST' }, POST_TIMEOUT_MS)
+function post(path: string, body?: unknown) {
+  const opts: RequestInit = { method: 'POST' }
+  if (body !== undefined) {
+    opts.body = JSON.stringify(body)
+    opts.headers = { 'Content-Type': 'application/json' }
+  }
+  return req<ActionAccepted>(path, opts, POST_TIMEOUT_MS)
 }
 
 export const api = {
@@ -85,6 +93,7 @@ export const api = {
 
   // ── Apps ────────────────────────────────────────────────────────────────
   listApps:   ()             => req<AppInfo[]>('/apps'),
+  getAppDetail: (name: string) => req<AppDetail>(`/apps/${enc(name)}/detail`),
   buildApp:   (name: string) => post(`/apps/${enc(name)}/build`),
   deployApp:  (name: string) => post(`/apps/${enc(name)}/deploy`),
   destroyApp: (name: string) => post(`/apps/${enc(name)}/destroy`),
@@ -95,12 +104,17 @@ export const api = {
   platformDown:  ()                          => post('/platform/down'),
   componentUp:   (cat: string, name: string) => post(`/platform/component/${enc(catSegment(cat))}/${enc(name)}/up`),
   componentDown: (cat: string, name: string) => post(`/platform/component/${enc(catSegment(cat))}/${enc(name)}/down`),
+  getComponent:  (cat: string, name: string) => req<PlatformComponentDetail>(`/platform/component/${enc(catSegment(cat))}/${enc(name)}`),
 
   // ── Scenarios ─────────────────────────────────────────────────────────────
   listScenarios: ()             => req<Scenario[]>('/scenarios'),
   getScenario:   (name: string) => req<Scenario>(`/scenarios/${enc(name)}`),
-  scenarioUp:    (name: string) => post(`/scenarios/${enc(name)}/up`),
+  scenarioUp:    (name: string, params?: Record<string, string>) =>
+    post(`/scenarios/${enc(name)}/up`, params && Object.keys(params).length ? { params } : undefined),
   scenarioDown:  (name: string) => post(`/scenarios/${enc(name)}/down`),
+  // Verify is synchronous: it returns the per-check results directly (not a job),
+  // so it parses the ScenarioVerifyResult body rather than an ActionAccepted.
+  scenarioVerify: (name: string) => req<ScenarioVerifyResult>(`/scenarios/${enc(name)}/verify`, { method: 'POST' }, POST_TIMEOUT_MS),
 
   // ── Runtimes ──────────────────────────────────────────────────────────────
   listRuntimes:     ()             => req<Runtime[]>('/runtimes'),

--- a/src/ui/src/components/Icon.tsx
+++ b/src/ui/src/components/Icon.tsx
@@ -21,7 +21,7 @@ export type IconName =
   | 'check' | 'check-circle' | 'x-circle' | 'alert-triangle' | 'info'
   | 'x' | 'chevron-down' | 'chevron-up' | 'chevron-right' | 'arrow-right'
   | 'play' | 'stop' | 'clock' | 'zap' | 'plus' | 'trash' | 'hammer'
-  | 'lightbulb' | 'target' | 'terminal' | 'dot'
+  | 'lightbulb' | 'target' | 'terminal' | 'dot' | 'trending-up'
 
 // Inner markup per icon. Paths use round joins/caps set on the parent <svg>.
 const PATHS: Record<IconName, JSX.Element> = {
@@ -77,6 +77,7 @@ const PATHS: Record<IconName, JSX.Element> = {
   target: <><circle cx="12" cy="12" r="10" /><circle cx="12" cy="12" r="6" /><circle cx="12" cy="12" r="2" /></>,
   terminal: <><polyline points="4 17 10 11 4 5" /><line x1="12" y1="19" x2="20" y2="19" /></>,
   dot: <><circle cx="12" cy="12" r="5" /></>,
+  'trending-up': <><polyline points="22 7 13.5 15.5 8.5 10.5 2 17" /><polyline points="16 7 22 7 22 13" /></>,
 }
 
 interface IconProps extends Omit<SVGProps<SVGSVGElement>, 'name'> {

--- a/src/ui/src/index.css
+++ b/src/ui/src/index.css
@@ -502,6 +502,71 @@ code, pre, .mono { font-family: var(--font-mono); }
 .scenario-actions { display: flex; gap: var(--space-2); align-items: center; flex-shrink: 0; flex-wrap: wrap; }
 .scenario-meta { color: var(--muted); font-size: var(--text-xs); margin-top: var(--space-1); }
 
+/* Scenario rows are wrapped in .scenario-item so verify results can render
+ * beneath each row while the row keeps its own separator. */
+.scenario-item:last-child .scenario-row { border-bottom: none; }
+
+/* Autoscaler (HPA) summary on an app card: replica bounds + the driving metric
+ * against its target, so "why did it scale" is answerable without a terminal. */
+.hpa-line {
+  display: flex; align-items: center; gap: var(--space-2); flex-wrap: wrap;
+  margin-top: var(--space-2);
+  font-size: var(--text-xs); font-family: var(--font-mono);
+  color: var(--text);
+}
+.hpa-icon { color: var(--accent); flex-shrink: 0; }
+.hpa-label {
+  text-transform: uppercase; letter-spacing: .04em; font-size: 10px;
+  color: var(--accent); font-weight: 600;
+}
+.hpa-stat {
+  background: var(--surface-2); border: 1px solid var(--border);
+  border-radius: var(--radius-sm); padding: 1px 6px;
+  font-variant-numeric: tabular-nums;
+}
+.hpa-stat.hpa-metric { background: var(--accent-soft); border-color: transparent; color: var(--text-strong); }
+.hpa-stat.hpa-pending { background: var(--warning-soft); border-color: transparent; color: var(--warning); }
+.hpa-stat.hpa-bounds { color: var(--muted); }
+
+/* Scenario verify results (per-check PASS/FAIL breakdown). */
+.verify-results { margin: var(--space-3) 0 var(--space-2); display: flex; flex-direction: column; gap: var(--space-2); }
+.verify-error { color: var(--danger); }
+
+/* Parameter form in the Activate dialog (tunable scenario knobs). */
+.param-form { display: flex; flex-direction: column; gap: var(--space-3); margin-top: var(--space-2); }
+.param-field { display: flex; flex-direction: column; gap: 3px; }
+.param-field > label { font-size: var(--text-sm); font-weight: 500; color: var(--text-strong); }
+.param-input {
+  width: 100%; max-width: 220px;
+  padding: 6px 10px;
+  background: var(--surface); color: var(--text);
+  border: 1px solid var(--border-strong); border-radius: var(--radius-sm);
+  font-family: var(--font-mono); font-size: var(--text-sm);
+}
+.param-input:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+
+/* Default-credential hint under the Grafana dashboard link. */
+.cred-hint { margin-top: var(--space-3); }
+.cred-hint code { background: var(--surface-2); padding: 1px 5px; border-radius: var(--radius-sm); }
+
+/* Scenario snippets ("How it's implemented") — the manifest a learner applies. */
+.snippet { border: 1px solid var(--border); border-radius: var(--radius-md); padding: var(--space-3); background: var(--surface-2); }
+.snippet-head { display: flex; align-items: flex-start; justify-content: space-between; gap: var(--space-2); }
+.snippet-label { font-weight: 500; color: var(--text-strong); font-size: var(--text-sm); }
+/* The copy control is absolutely positioned inside .cmd-block, but here it is a
+ * flex child of the header row — pin it back to static so it sits at the end. */
+.snippet-head .cmd-copy { position: static; flex-shrink: 0; }
+.snippet-desc { color: var(--text); font-size: var(--text-sm); margin: 3px 0 var(--space-2); }
+.snippet-source { margin: 3px 0 var(--space-2); }
+.snippet-source code { background: var(--surface-3); padding: 1px 5px; border-radius: var(--radius-sm); }
+.snippet-code {
+  margin: 0; padding: var(--space-3);
+  background: var(--surface); color: var(--text);
+  border: 1px solid var(--border); border-radius: var(--radius-sm);
+  font-family: var(--font-mono); font-size: var(--text-xs); line-height: 1.5;
+  overflow-x: auto; white-space: pre;
+}
+
 /* Inline verified / meta hint text */
 .hint-text { color: var(--muted); font-size: var(--text-xs); }
 .hint-inline { color: var(--muted); font-size: var(--text-sm); }
@@ -881,6 +946,15 @@ code, pre, .mono { font-family: var(--font-mono); }
   transition: color .15s, border-color .15s;
 }
 .cmd-copy:hover { color: var(--accent); border-color: var(--accent); }
+
+/* Install-command variable legend (platform component details) */
+.install-vars { margin-top: var(--space-3); }
+.install-vars .hint-text { margin-bottom: var(--space-2); }
+.var-table { width: 100%; border-collapse: collapse; font-size: var(--text-sm); }
+.var-table td { padding: var(--space-2) var(--space-3); border-top: 1px solid var(--border); vertical-align: top; }
+.var-table td:first-child { white-space: nowrap; }
+.var-table code { font-family: var(--font-mono); background: var(--muted-soft); padding: 1px 5px; border-radius: 4px; }
+.var-table .var-desc { color: var(--muted); font-family: var(--font-sans); }
 
 /* Inline code snippet used for CLI hints in rows */
 .cli-hint { font-size: var(--text-xs); color: var(--muted); }

--- a/src/ui/src/types/index.ts
+++ b/src/ui/src/types/index.ts
@@ -74,7 +74,16 @@ export interface PlatformComponentDetail {
   chart: string
   /** The helm/kubectl commands install.sh actually runs, for "how it's set up". */
   installCommands: string[]
+  /** Legend for the shell variables appearing in installCommands. */
+  installVars?: InstallVar[]
   usedInScenarios: ScenarioRef[]
+}
+
+/** One shell variable referenced by a component's install commands. */
+export interface InstallVar {
+  name: string
+  value: string
+  description: string
 }
 
 /** One source file surfaced on an app's details page. */
@@ -95,7 +104,6 @@ export interface AppDetail {
   dockerfile?: AppFileRef
   chartYaml?: AppFileRef
   valuesFile?: AppFileRef
-  entrypoint?: AppFileRef
   helmChartPath?: string
   templates?: string[]
 }

--- a/src/ui/src/types/index.ts
+++ b/src/ui/src/types/index.ts
@@ -54,6 +54,67 @@ export interface PlatformProviderEntry {
  *  Category keys may be nested ("monitoring/metrics"). */
 export type PlatformProvidersMap = Record<string, PlatformProviderEntry[]>
 
+/** A compact scenario pointer (used by the "used in scenarios" list). */
+export interface ScenarioRef {
+  name: string
+  displayName: string
+}
+
+/** GET /api/platform/component/:cat/:name — the per-tool details page. */
+export interface PlatformComponentDetail {
+  category: string
+  name: string
+  namespace: string
+  installed: boolean
+  description: string
+  provides: string[]
+  ports: string[]
+  dependencies: string[]
+  resources: string[]
+  chart: string
+  /** The helm/kubectl commands install.sh actually runs, for "how it's set up". */
+  installCommands: string[]
+  usedInScenarios: ScenarioRef[]
+}
+
+/** One source file surfaced on an app's details page. */
+export interface AppFileRef {
+  path: string
+  content: string
+  truncated?: boolean
+}
+
+/** GET /api/apps/:name/detail — how an app is built and deployed. */
+export interface AppDetail {
+  name: string
+  description: string
+  tech: string[]
+  buildStrategy: string
+  deployStrategy: string
+  namespace: string
+  dockerfile?: AppFileRef
+  chartYaml?: AppFileRef
+  valuesFile?: AppFileRef
+  entrypoint?: AppFileRef
+  helmChartPath?: string
+  templates?: string[]
+}
+
+/** Live HorizontalPodAutoscaler state for an app (present ⇔ an HPA, including a
+ *  KEDA-managed one, targets it). Metric* strings are pre-rendered by the API,
+ *  e.g. current "27467m" vs target "25", or "92%" vs "80%" for a CPU HPA. */
+export interface HPAStatus {
+  present: boolean
+  name: string
+  minReplicas: number
+  maxReplicas: number
+  currentReplicas: number
+  desiredReplicas: number
+  metricName?: string
+  metricCurrent?: string
+  metricTarget?: string
+}
+
 export interface AppInfo {
   name: string
   buildStrategy: string
@@ -64,6 +125,8 @@ export interface AppInfo {
   namespace?: string
   /** Ingress URL (http://<app>.<domainSuffix>), set once deployed. */
   url?: string
+  /** Autoscaler state, present only when an HPA targets the app. */
+  hpa?: HPAStatus
 }
 
 export interface StatusResponse {
@@ -106,6 +169,44 @@ export interface ScenarioComponent {
   version?: string
 }
 
+/** A user-tunable knob a scenario exposes at activation time (e.g. an
+ *  autoscaler's min/max replicas and threshold). Substituted into the scenario's
+ *  manifests as a {{.name}} template variable. */
+export interface ScenarioParameter {
+  name: string
+  displayName?: string
+  description?: string
+  default: string
+  type?: 'int' | 'string'
+  min?: number
+  max?: number
+  notGreaterThan?: string
+}
+
+/** A machine-verifiable check declared by a scenario (pkg/checks.Check). The
+ *  assertion is either a kubectl resource/jsonpath or a promql query, compared
+ *  to `value` with `operator`. */
+export interface ScenarioCheck {
+  name: string
+  type?: string
+  resource?: string
+  namespace?: string
+  jsonpath?: string
+  query?: string
+  operator?: string
+  value?: string
+}
+
+/** An applyable manifest fragment a scenario surfaces for hands-on learning.
+ *  `yaml` carries the display content (inlined from `path` by the server, with
+ *  parameter defaults resolved); `path` names its source file. */
+export interface ScenarioSnippet {
+  label: string
+  description?: string
+  yaml?: string
+  path?: string
+}
+
 export interface Scenario {
   name: string
   displayName: string
@@ -116,6 +217,30 @@ export interface Scenario {
   prerequisites?: ScenarioPrerequisites
   components?: ScenarioComponent[]
   explore?: Explore
+  parameters?: ScenarioParameter[]
+  objectives?: string[]
+  checks?: ScenarioCheck[]
+  snippets?: ScenarioSnippet[]
+}
+
+/** One check outcome from POST /api/scenarios/{name}/verify (pkg/checks.Result).
+ *  Pass ⇔ the asserted post-state holds. */
+export interface ScenarioCheckResult {
+  name: string
+  type?: string
+  pass: boolean
+  got?: string
+  want?: string
+  explanation?: string
+  error?: string
+  durationMs?: number
+}
+
+/** POST /api/scenarios/{name}/verify response. */
+export interface ScenarioVerifyResult {
+  scenario: string
+  passed: boolean
+  results: ScenarioCheckResult[]
 }
 
 // ── Dashboards & Runtimes ────────────────────────────────────────────────────

--- a/src/ui/src/views/Apps.tsx
+++ b/src/ui/src/views/Apps.tsx
@@ -280,7 +280,6 @@ function AppDetailModal({ detail, loading, onClose, onCopy }: {
             {detail.dockerfile && <FileBlock label="Dockerfile" file={detail.dockerfile} onCopy={onCopy} />}
             {detail.valuesFile && <FileBlock label="Helm values (used by Deploy)" file={detail.valuesFile} onCopy={onCopy} />}
             {detail.chartYaml && <FileBlock label="Chart.yaml" file={detail.chartYaml} onCopy={onCopy} />}
-            {detail.entrypoint && <FileBlock label="Entrypoint" file={detail.entrypoint} onCopy={onCopy} />}
 
             {templates.length > 0 && (
               <div className="modal-section">

--- a/src/ui/src/views/Apps.tsx
+++ b/src/ui/src/views/Apps.tsx
@@ -1,8 +1,9 @@
+import { useState } from 'react'
 import { api } from '../api/client'
 import { qk } from '../lib/queryClient'
 import { useApiQuery } from '../hooks/useApiQuery'
-import type { AppInfo, NotifyFn } from '../types'
-import { DeployedBadge } from '../components/Badge'
+import type { AppInfo, AppDetail, AppFileRef, NotifyFn } from '../types'
+import { Badge, DeployedBadge } from '../components/Badge'
 import { ErrorState } from '../components/ErrorState'
 import { Icon } from '../components/Icon'
 import { useJobRunner } from '../hooks/useJobRunner'
@@ -13,6 +14,20 @@ interface AppsProps {
   requestConfirm: (req: ConfirmRequest) => void
 }
 
+/** Turns a raw HPA metric name into readable words, e.g.
+ *  "go_api_requests_per_second" → "go api requests per second". */
+function prettyMetricName(name?: string): string {
+  return (name || 'metric').replace(/_/g, ' ')
+}
+
+/** Plain-English tooltip explaining the autoscaler's driving metric so a user
+ *  doesn't have to decode "0.3 / 25" — what it is, and when it scales. */
+function hpaMetricTitle(hpa: NonNullable<AppInfo['hpa']>): string {
+  const metric = prettyMetricName(hpa.metricName)
+  return `Current ${hpa.metricCurrent || '0'} vs target ${hpa.metricTarget} of "${metric}", averaged across replicas. ` +
+    `The autoscaler adds replicas when the average exceeds the target and removes them when it stays below.`
+}
+
 export function Apps({ notify, requestConfirm }: AppsProps) {
   // /status carries apps + domainSuffix + platform in one call; the Dashboard
   // shares this same cache key, so both views fetch it once.
@@ -21,6 +36,30 @@ export function Apps({ notify, requestConfirm }: AppsProps) {
   const suffix = data?.domainSuffix ?? ''
   const loggingActive = Boolean(data?.platform?.logging?.active)
   const { busy, run } = useJobRunner(notify)
+  const [detail, setDetail] = useState<AppDetail | null>(null)
+  const [detailLoading, setDetailLoading] = useState(false)
+
+  async function openDetail(a: AppInfo) {
+    setDetailLoading(true)
+    setDetail({ name: a.name, description: '', tech: [], buildStrategy: '', deployStrategy: '', namespace: a.namespace || a.name })
+    try {
+      setDetail(await api.getAppDetail(a.name))
+    } catch (e) {
+      notify('error', 'Failed to load app details', e instanceof Error ? e.message : String(e))
+      setDetail(null)
+    } finally {
+      setDetailLoading(false)
+    }
+  }
+
+  async function copyText(text: string) {
+    try {
+      await navigator.clipboard.writeText(text)
+      notify('success', 'Copied to clipboard', '')
+    } catch {
+      notify('error', 'Copy failed', 'Clipboard access denied — copy manually.')
+    }
+  }
 
   function openLogs(a: AppInfo) {
     if (!suffix) {
@@ -32,9 +71,19 @@ export function Apps({ notify, requestConfirm }: AppsProps) {
       return
     }
     const ns = a.namespace || a.name
-    const query = `{namespace="${ns}"}`
-    const explore = JSON.stringify({ datasource: 'Loki', queries: [{ refId: 'A', expr: query }] })
-    window.open(`http://grafana.${suffix}/explore?orgId=1&left=${encodeURIComponent(explore)}`, '_blank', 'noopener')
+    // Grafana 11+ Explore uses ?panes=<json> keyed by a pane id and resolves the
+    // datasource by UID (the old ?left=<name> opens an empty Explore). "loki" is
+    // the stable UID the Grafana datasource is provisioned with.
+    const panes = {
+      exp: {
+        datasource: 'loki',
+        queries: [{ refId: 'A', datasource: { type: 'loki', uid: 'loki' }, expr: `{namespace="${ns}"}` }],
+        // 6h window: the lab's apps are quiet (log mostly at startup), so a 1h
+        // default often shows "No logs found" even though logs exist.
+        range: { from: 'now-6h', to: 'now' },
+      },
+    }
+    window.open(`http://grafana.${suffix}/explore?orgId=1&schemaVersion=1&panes=${encodeURIComponent(JSON.stringify(panes))}`, '_blank', 'noopener')
   }
 
   if (loading) return <div className="loading" role="status">Loading apps…</div>
@@ -89,6 +138,22 @@ export function Apps({ notify, requestConfirm }: AppsProps) {
                   build: {a.buildStrategy || '—'} · deploy: {a.deployStrategy || '—'}
                   {a.replicas && ` · replicas: ${a.replicas}`}
                   {a.ready && ` · ready: ${a.ready}`}
+                  {a.hpa && (
+                    <div className="hpa-line" title={`Autoscaler ${a.hpa.name}: scales between ${a.hpa.minReplicas} and ${a.hpa.maxReplicas} replicas on ${a.hpa.metricName || 'a metric'}`}>
+                      <Icon name="trending-up" size={13} className="hpa-icon" />
+                      <span className="hpa-label">autoscaling</span>
+                      <span className="hpa-stat">{a.hpa.currentReplicas}/{a.hpa.maxReplicas} replicas</span>
+                      {a.hpa.desiredReplicas !== a.hpa.currentReplicas && (
+                        <span className="hpa-stat hpa-pending">→ desired {a.hpa.desiredReplicas}</span>
+                      )}
+                      {a.hpa.metricTarget && (
+                        <span className="hpa-stat hpa-metric" title={hpaMetricTitle(a.hpa)}>
+                          {prettyMetricName(a.hpa.metricName)}: {a.hpa.metricCurrent || '0'} / {a.hpa.metricTarget}
+                        </span>
+                      )}
+                      <span className="hpa-stat hpa-bounds">min {a.hpa.minReplicas} · max {a.hpa.maxReplicas}</span>
+                    </div>
+                  )}
                 </div>
 
                 <DeployedBadge deployed={a.deployed} />
@@ -105,6 +170,7 @@ export function Apps({ notify, requestConfirm }: AppsProps) {
                       Open <Icon name="external" size={14} />
                     </a>
                   )}
+                  <button className="btn btn-sm" onClick={() => openDetail(a)}>Details</button>
                   <button
                     className="btn btn-sm"
                     onClick={() => openLogs(a)}
@@ -144,6 +210,91 @@ export function Apps({ notify, requestConfirm }: AppsProps) {
           </div>
         )}
       </div>
+
+      {detail && (
+        <AppDetailModal
+          detail={detail}
+          loading={detailLoading}
+          onClose={() => setDetail(null)}
+          onCopy={copyText}
+        />
+      )}
     </>
+  )
+}
+
+/** Per-app details: what it is, its stack, and the real Dockerfile + Helm chart
+ *  (with repo paths) so a learner can find the files and rebuild/redeploy it. */
+function FileBlock({ label, file, onCopy }: { label: string; file: AppFileRef; onCopy: (t: string) => void }) {
+  return (
+    <div className="modal-section">
+      <h3>{label} <span className="hint-text">{file.path}</span></h3>
+      <div className="cmd-block cmd-block-multiline">
+        <button className="cmd-copy" onClick={() => onCopy(file.content)}>Copy</button>
+        <pre className="snippet-code">{file.content}</pre>
+      </div>
+      {file.truncated && <div className="field-help">Showing the first part of the file — open <code>{file.path}</code> for the full contents.</div>}
+    </div>
+  )
+}
+
+function AppDetailModal({ detail, loading, onClose, onCopy }: {
+  detail: AppDetail
+  loading: boolean
+  onClose: () => void
+  onCopy: (text: string) => void
+}) {
+  const tech = detail.tech ?? []
+  const templates = detail.templates ?? []
+  return (
+    <div className="modal-overlay" onClick={e => { if (e.target === e.currentTarget) onClose() }}>
+      <div className="modal-card" role="dialog" aria-modal="true" aria-label={`${detail.name} details`}>
+        <button className="modal-close" aria-label="Close details" onClick={onClose}><Icon name="x" size={18} /></button>
+
+        <div className="modal-header">
+          <h2>{detail.name}</h2>
+          <div className="modal-meta">
+            {tech.map(t => <Badge key={t} variant="category">{t}</Badge>)}
+          </div>
+        </div>
+
+        {loading ? (
+          <div className="loading" role="status">Loading…</div>
+        ) : (
+          <>
+            {detail.description && (
+              <div className="modal-section">
+                <h3>What it is</h3>
+                <p>{detail.description}</p>
+              </div>
+            )}
+
+            <div className="modal-section">
+              <h3>Build &amp; deploy</h3>
+              {detail.buildStrategy && <div className="field-help">Build strategy: <code>{detail.buildStrategy}</code></div>}
+              {detail.deployStrategy && <div className="field-help">Deploy strategy: <code>{detail.deployStrategy}</code></div>}
+              <div className="field-help">Namespace: <code>{detail.namespace}</code></div>
+              {detail.helmChartPath && <div className="field-help">Helm chart: <code>{detail.helmChartPath}</code></div>}
+            </div>
+
+            {detail.dockerfile && <FileBlock label="Dockerfile" file={detail.dockerfile} onCopy={onCopy} />}
+            {detail.valuesFile && <FileBlock label="Helm values (used by Deploy)" file={detail.valuesFile} onCopy={onCopy} />}
+            {detail.chartYaml && <FileBlock label="Chart.yaml" file={detail.chartYaml} onCopy={onCopy} />}
+            {detail.entrypoint && <FileBlock label="Entrypoint" file={detail.entrypoint} onCopy={onCopy} />}
+
+            {templates.length > 0 && (
+              <div className="modal-section">
+                <h3>Helm templates</h3>
+                <ul>{templates.map(t => <li key={t}><code>{t}</code></li>)}</ul>
+              </div>
+            )}
+          </>
+        )}
+
+        <div className="card-footer">
+          <button className="btn" onClick={onClose}>Close</button>
+        </div>
+      </div>
+    </div>
   )
 }

--- a/src/ui/src/views/Learn.test.tsx
+++ b/src/ui/src/views/Learn.test.tsx
@@ -49,7 +49,7 @@ function renderLearn() {
   const notify = vi.fn()
   render(
     <QueryClientProvider client={client}>
-      <Learn notify={notify} />
+      <Learn notify={notify} requestConfirm={vi.fn()} />
     </QueryClientProvider>,
   )
   return { notify }
@@ -90,7 +90,7 @@ describe('Learn view', () => {
     const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
     const { container } = render(
       <QueryClientProvider client={client}>
-        <Learn notify={vi.fn()} />
+        <Learn notify={vi.fn()} requestConfirm={vi.fn()} />
       </QueryClientProvider>,
     )
     await user.click(await screen.findByRole('button', { name: /details/i }))

--- a/src/ui/src/views/Learn.tsx
+++ b/src/ui/src/views/Learn.tsx
@@ -3,20 +3,23 @@ import { api } from '../api/client'
 import { qk } from '../lib/queryClient'
 import { useApiQuery } from '../hooks/useApiQuery'
 import type { LearnPathSummary, LearnPath, LearnProgress, NotifyFn } from '../types'
+import type { ConfirmRequest } from '../components/ConfirmDialog'
 import { Badge } from '../components/Badge'
 import { ErrorState } from '../components/ErrorState'
 import { Icon } from '../components/Icon'
 
 interface LearnProps {
   notify: NotifyFn
+  requestConfirm: (req: ConfirmRequest) => void
 }
 
-export function Learn({ notify }: LearnProps) {
+export function Learn({ notify, requestConfirm }: LearnProps) {
   const { data: paths = [], loading, loaded, loadError, refreshing, reload: load } = useApiQuery(qk.learnPaths, api.listLearnPaths)
   const [selected, setSelected] = useState<{ path: LearnPath; progress: LearnProgress } | null>(null)
   const [detailLoading, setDetailLoading] = useState(false)
   const [openingPath, setOpeningPath] = useState<string | null>(null)
   const [starting, setStarting] = useState<string | null>(null)
+  const [resetting, setResetting] = useState<string | null>(null)
   const [completingIdx, setCompletingIdx] = useState<number | null>(null)
 
   async function openPath(name: string) {
@@ -51,6 +54,31 @@ export function Learn({ notify }: LearnProps) {
     } finally {
       setStarting(null)
     }
+  }
+
+  // Reset a path's progress back to the beginning. Deliberately separate from a
+  // lab reset — the cluster and your progress are independent.
+  function resetPath(name: string) {
+    requestConfirm({
+      title: `Reset progress for "${name}"?`,
+      message: 'This clears your completed modules for this path so you start from the beginning. It does not touch the cluster. This cannot be undone.',
+      confirmLabel: 'Reset progress',
+      onConfirm: async () => {
+        setResetting(name)
+        try {
+          const progress = await api.resetLearnPath(name)
+          notify('success', `Reset "${name}"`, 'Progress cleared — start again from the first module.')
+          if (selected?.path.name === name) {
+            setSelected(prev => prev ? { ...prev, progress } : null)
+          }
+          load()
+        } catch (e) {
+          notify('error', 'Failed to reset progress', e instanceof Error ? e.message : String(e))
+        } finally {
+          setResetting(null)
+        }
+      },
+    })
   }
 
   // Completing a module is the core of the in-UI progression: the learner works
@@ -170,6 +198,16 @@ export function Learn({ notify }: LearnProps) {
                     <button className="btn btn-sm" onClick={() => openPath(p.name)} disabled={openingPath === p.name}>
                       {openingPath === p.name ? 'Loading…' : 'Details'}
                     </button>
+                    {p.completedCount > 0 && (
+                      <button
+                        className="btn btn-sm btn-danger"
+                        disabled={resetting === p.name}
+                        title="Clear your progress for this path and start from the beginning (does not affect the cluster)"
+                        onClick={() => resetPath(p.name)}
+                      >
+                        {resetting === p.name ? 'Resetting…' : 'Reset progress'}
+                      </button>
+                    )}
                   </div>
                 </div>
               )

--- a/src/ui/src/views/Platform.tsx
+++ b/src/ui/src/views/Platform.tsx
@@ -232,9 +232,20 @@ export function Platform({ notify, requestConfirm }: PlatformProps) {
               ))}
             </div>
             {dashboards.some(d => d.name === 'grafana') && (
-              <div className="field-help cred-hint">
-                Grafana login: <code>admin</code> / <code>admin</code> (default — override with the <code>GRAFANA_ADMIN_PASSWORD</code> env var before installing).
-              </div>
+              <details className="grafana-guide">
+                <summary>Configuring Grafana</summary>
+                <div className="field-help">
+                  <p><strong>Log in:</strong> <code>admin</code> / <code>admin</code> (override with the <code>GRAFANA_ADMIN_PASSWORD</code> env var before installing).</p>
+                  <p><strong>Data sources</strong> are auto-provisioned — you don't create them by hand. Three come pre-wired, each with a fixed UID you'll see referenced in panels:</p>
+                  <ul>
+                    <li><code>Prometheus</code> (uid <code>prometheus</code>) — metrics, the default source</li>
+                    <li><code>Loki</code> (uid <code>loki</code>) — logs</li>
+                    <li><code>Tempo</code> (uid <code>tempo</code>) — traces</li>
+                  </ul>
+                  <p><strong>Dashboards</strong> are auto-provisioned too: the baseline set ships with Grafana, and each scenario adds its own when you activate it. Find them under <em>Dashboards</em> in Grafana — no import needed.</p>
+                  <p><strong>Reading a panel:</strong> if a query shows a <code>$</code> variable (e.g. <code>$__rate_interval</code>), that's Grafana's own interval macro and resolves automatically. The install commands on each component's <em>Details</em> page already have their <code>$NAMESPACE</code> / <code>{'${DOMAIN_SUFFIX}'}</code> filled in with this lab's values.</p>
+                </div>
+              </details>
             )}
           </>
         )}

--- a/src/ui/src/views/Platform.tsx
+++ b/src/ui/src/views/Platform.tsx
@@ -291,6 +291,7 @@ function ComponentDetailModal({ detail, loading, onClose, onCopy }: {
   const dependencies = detail.dependencies ?? []
   const resources = detail.resources ?? []
   const installCommands = detail.installCommands ?? []
+  const installVars = detail.installVars ?? []
   const usedInScenarios = detail.usedInScenarios ?? []
   return (
     <div className="modal-overlay" onClick={e => { if (e.target === e.currentTarget) onClose() }}>
@@ -342,6 +343,22 @@ function ComponentDetailModal({ detail, loading, onClose, onCopy }: {
                     <button className="cmd-copy" onClick={() => onCopy(cmd)}>Copy</button>
                   </div>
                 ))}
+                {installVars.length > 0 && (
+                  <div className="install-vars">
+                    <div className="hint-text">Variables used in these commands:</div>
+                    <table className="var-table">
+                      <tbody>
+                        {installVars.map(v => (
+                          <tr key={v.name}>
+                            <td><code>${'{'}{v.name}{'}'}</code></td>
+                            <td>{v.value ? <code>{v.value}</code> : <span className="hint-text">set via environment</span>}</td>
+                            <td className="var-desc">{v.description}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
               </div>
             )}
 

--- a/src/ui/src/views/Platform.tsx
+++ b/src/ui/src/views/Platform.tsx
@@ -1,7 +1,8 @@
+import { useState } from 'react'
 import { api } from '../api/client'
 import { qk } from '../lib/queryClient'
 import { useApiQuery } from '../hooks/useApiQuery'
-import type { PlatformProviderEntry, DashboardURL, NotifyFn } from '../types'
+import type { PlatformProviderEntry, PlatformComponentDetail, DashboardURL, NotifyFn } from '../types'
 import { Badge } from '../components/Badge'
 import { ErrorState } from '../components/ErrorState'
 import { Icon } from '../components/Icon'
@@ -45,6 +46,30 @@ export function Platform({ notify, requestConfirm }: PlatformProps) {
   const dashQ = useApiQuery(qk.dashboards, () => api.getDashboards().catch(() => [] as DashboardURL[]), { refetchInterval: 15_000 })
   const dashboards = (dashQ.data ?? []).filter(d => d.available)
   const { busy, run } = useJobRunner(notify)
+  const [detail, setDetail] = useState<PlatformComponentDetail | null>(null)
+  const [detailLoading, setDetailLoading] = useState(false)
+
+  async function openDetail(entry: PlatformProviderEntry) {
+    setDetailLoading(true)
+    setDetail({ category: entry.category, name: entry.name, namespace: '', installed: entry.installed, description: '', provides: [], ports: [], dependencies: [], resources: [], chart: '', installCommands: [], usedInScenarios: [] })
+    try {
+      setDetail(await api.getComponent(entry.category, entry.name))
+    } catch (e) {
+      notify('error', 'Failed to load component details', e instanceof Error ? e.message : String(e))
+      setDetail(null)
+    } finally {
+      setDetailLoading(false)
+    }
+  }
+
+  async function copyCmd(cmd: string) {
+    try {
+      await navigator.clipboard.writeText(cmd)
+      notify('success', 'Copied to clipboard', '')
+    } catch {
+      notify('error', 'Copy failed', 'Clipboard access denied — copy the command manually.')
+    }
+  }
 
   function install(entry: PlatformProviderEntry, installedSibling?: PlatformProviderEntry) {
     const key = `${entry.category}/${entry.name}`
@@ -131,6 +156,7 @@ export function Platform({ notify, requestConfirm }: PlatformProps) {
                           <Badge variant={entry.installed ? 'running' : 'stopped'}>
                             {entry.installed ? 'Installed' : 'Not Installed'}
                           </Badge>
+                          <button className="btn btn-sm" onClick={() => openDetail(entry)}>Details</button>
                           {entry.installed ? (
                             <button
                               className="btn btn-sm btn-danger"
@@ -197,15 +223,123 @@ export function Platform({ notify, requestConfirm }: PlatformProps) {
             <div className="empty-hint">Install a component above (e.g. Grafana, Traefik, ArgoCD) and its dashboard link appears here.</div>
           </div>
         ) : (
-          <div className="quick-links">
-            {dashboards.map(d => (
-              <a key={d.name} className="quick-link" href={d.url} target="_blank" rel="noopener noreferrer">
-                {d.label} <Icon name="external" size={14} />
-              </a>
-            ))}
-          </div>
+          <>
+            <div className="quick-links">
+              {dashboards.map(d => (
+                <a key={d.name} className="quick-link" href={d.url} target="_blank" rel="noopener noreferrer">
+                  {d.label} <Icon name="external" size={14} />
+                </a>
+              ))}
+            </div>
+            {dashboards.some(d => d.name === 'grafana') && (
+              <div className="field-help cred-hint">
+                Grafana login: <code>admin</code> / <code>admin</code> (default — override with the <code>GRAFANA_ADMIN_PASSWORD</code> env var before installing).
+              </div>
+            )}
+          </>
         )}
       </div>
+
+      {detail && (
+        <ComponentDetailModal
+          detail={detail}
+          loading={detailLoading}
+          onClose={() => setDetail(null)}
+          onCopy={copyCmd}
+        />
+      )}
     </>
+  )
+}
+
+/** Per-tool details: what it is, what it provides/needs, the exact helm/kubectl
+ *  commands install.sh runs, and which scenarios depend on it. */
+function ComponentDetailModal({ detail, loading, onClose, onCopy }: {
+  detail: PlatformComponentDetail
+  loading: boolean
+  onClose: () => void
+  onCopy: (cmd: string) => void
+}) {
+  // The API can send JSON null for empty lists (Go nil slices); coerce to arrays
+  // so the `.length` reads below never crash the view.
+  const provides = detail.provides ?? []
+  const ports = detail.ports ?? []
+  const dependencies = detail.dependencies ?? []
+  const resources = detail.resources ?? []
+  const installCommands = detail.installCommands ?? []
+  const usedInScenarios = detail.usedInScenarios ?? []
+  return (
+    <div className="modal-overlay" onClick={e => { if (e.target === e.currentTarget) onClose() }}>
+      <div className="modal-card" role="dialog" aria-modal="true" aria-label={`${detail.name} details`}>
+        <button className="modal-close" aria-label="Close details" onClick={onClose}><Icon name="x" size={18} /></button>
+
+        <div className="modal-header">
+          <h2>{detail.name}</h2>
+          <div className="modal-meta">
+            <Badge variant="category">{detail.category}</Badge>
+            <Badge variant={detail.installed ? 'running' : 'stopped'}>{detail.installed ? 'Installed' : 'Not Installed'}</Badge>
+          </div>
+        </div>
+
+        {loading ? (
+          <div className="loading" role="status">Loading…</div>
+        ) : (
+          <>
+            {detail.description && (
+              <div className="modal-section">
+                <h3>What it is</h3>
+                <p>{detail.description}</p>
+                {detail.chart && <div className="hint-text">Helm chart: <code>{detail.chart}</code> · Namespace: <code>{detail.namespace}</code></div>}
+              </div>
+            )}
+
+            {provides.length > 0 && (
+              <div className="modal-section">
+                <h3>What you can do with it</h3>
+                <ul>{provides.map((p, i) => <li key={i}>{p}</li>)}</ul>
+              </div>
+            )}
+
+            {(dependencies.length > 0 || ports.length > 0 || resources.length > 0) && (
+              <div className="modal-section">
+                <h3>Requires</h3>
+                {dependencies.length > 0 && <div className="field-help">Depends on: {dependencies.join(', ')}</div>}
+                {ports.length > 0 && <div className="field-help">Ports: {ports.join(', ')}</div>}
+                {resources.length > 0 && <div className="field-help">Cluster resources: {resources.join(', ')}</div>}
+              </div>
+            )}
+
+            {installCommands.length > 0 && (
+              <div className="modal-section">
+                <h3>How it's installed <span className="hint-text">(what the Install button runs)</span></h3>
+                {installCommands.map((cmd, i) => (
+                  <div key={i} className="cmd-block">
+                    <code>{cmd}</code>
+                    <button className="cmd-copy" onClick={() => onCopy(cmd)}>Copy</button>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            <div className="modal-section">
+              <h3>Used in scenarios</h3>
+              {usedInScenarios.length > 0 ? (
+                <div className="prereq-chips">
+                  {usedInScenarios.map(s => (
+                    <Badge key={s.name} variant="category">{s.displayName || s.name}</Badge>
+                  ))}
+                </div>
+              ) : (
+                <div className="field-help">No scenario lists this as a prerequisite — it's available for ad-hoc use.</div>
+              )}
+            </div>
+          </>
+        )}
+
+        <div className="card-footer">
+          <button className="btn" onClick={onClose}>Close</button>
+        </div>
+      </div>
+    </div>
   )
 }

--- a/src/ui/src/views/Platform.tsx
+++ b/src/ui/src/views/Platform.tsx
@@ -205,6 +205,19 @@ export function Platform({ notify, requestConfirm }: PlatformProps) {
           >
             Remove baseline
           </button>
+          <button
+            className="btn btn-danger platform-reset"
+            disabled={busy['lab-reset']}
+            title="Tear the lab back to its initial state: deactivate all scenarios and incidents, destroy deployed apps, and uninstall non-baseline platform components. The cluster itself stays up."
+            onClick={() => requestConfirm({
+              title: 'Reset the whole lab?',
+              message: 'This deactivates every scenario and incident, destroys all deployed apps, and uninstalls every platform component except the ingress baseline. The cluster stays up, and your learning progress is kept. Scenarios and incidents can be re-activated afterwards. This cannot be undone — consider taking a snapshot first.',
+              confirmLabel: 'Reset lab',
+              onConfirm: () => run('lab-reset', 'Reset lab', () => api.resetLab(), () => { load(); dashQ.reload() }),
+            })}
+          >
+            {busy['lab-reset'] ? 'Resetting…' : (<><Icon name="refresh" size={15} />Reset lab</>)}
+          </button>
         </div>
       </div>
 

--- a/src/ui/src/views/Scenarios.test.tsx
+++ b/src/ui/src/views/Scenarios.test.tsx
@@ -12,10 +12,10 @@ import type { Scenario } from '../types'
 import type { ConfirmRequest } from '../components/ConfirmDialog'
 
 vi.mock('../api/client', () => ({
-  api: { listScenarios: vi.fn(), getScenario: vi.fn(), scenarioUp: vi.fn(), scenarioDown: vi.fn() },
+  api: { listScenarios: vi.fn(), getScenario: vi.fn(), scenarioUp: vi.fn(), scenarioDown: vi.fn(), scenarioVerify: vi.fn() },
 }))
 import { api } from '../api/client'
-const mockApi = api as unknown as { listScenarios: Mock; getScenario: Mock; scenarioUp: Mock; scenarioDown: Mock }
+const mockApi = api as unknown as { listScenarios: Mock; getScenario: Mock; scenarioUp: Mock; scenarioDown: Mock; scenarioVerify: Mock }
 
 const gitops: Scenario = {
   name: 'gitops-cicd', displayName: 'GitOps & CI/CD', description: 'ArgoCD GitOps',
@@ -66,6 +66,104 @@ describe('Scenarios view — activation preview', () => {
     // scenarioUp only fires once the user confirms.
     expect(mockApi.scenarioUp).not.toHaveBeenCalled()
     req.onConfirm()
-    await waitFor(() => expect(mockApi.scenarioUp).toHaveBeenCalledWith('gitops-cicd'))
+    // A scenario with no parameters activates with an empty override map.
+    await waitFor(() => expect(mockApi.scenarioUp).toHaveBeenCalledWith('gitops-cicd', {}))
+  })
+})
+
+describe('Scenarios view — parameters', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  const withParams: Scenario = {
+    ...gitops,
+    parameters: [
+      { name: 'Threshold', displayName: 'RPS per replica', default: '25', type: 'int', min: 1, max: 500 },
+    ],
+  }
+
+  it('shows tunable parameters seeded to defaults and submits overrides on confirm', async () => {
+    const user = userEvent.setup()
+    mockApi.listScenarios.mockResolvedValue([{ ...withParams }])
+    mockApi.getScenario.mockResolvedValue(withParams)
+    mockApi.scenarioUp.mockResolvedValue({ jobId: 'j1', status: 'accepted' })
+
+    const { getConfirm } = renderScenarios()
+    await user.click(await screen.findByRole('button', { name: /^activate$/i }))
+    await waitFor(() => expect(getConfirm()).not.toBeNull())
+    const req = getConfirm()!
+    render(<div>{req.message as React.ReactNode}</div>)
+
+    const input = screen.getByLabelText(/RPS per replica/i) as HTMLInputElement
+    expect(input.value).toBe('25') // seeded to the declared default
+
+    await user.clear(input)
+    await user.type(input, '15')
+
+    req.onConfirm()
+    await waitFor(() => expect(mockApi.scenarioUp).toHaveBeenCalledWith('gitops-cicd', { Threshold: '15' }))
+  })
+})
+
+describe('Scenarios view — detail modal teaches implementation', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  const rich: Scenario = {
+    ...gitops,
+    objectives: ['Declare a KEDA ScaledObject'],
+    snippets: [{ label: 'The ScaledObject', path: 'manifests/scaledobject.yaml', yaml: 'kind: ScaledObject\nthreshold: 25' }],
+    checks: [{ name: 'keda-hpa-created', type: 'kubectl', resource: 'hpa/keda-hpa-go-api', operator: 'exists' }],
+  }
+
+  it('renders objectives, the implementation snippet, and the success checks', async () => {
+    const user = userEvent.setup()
+    mockApi.listScenarios.mockResolvedValue([{ ...rich }])
+    mockApi.getScenario.mockResolvedValue(rich)
+
+    renderScenarios()
+    await user.click(await screen.findByRole('button', { name: /details/i }))
+
+    // Objectives, snippet content (the actual manifest), and check assertion all show.
+    expect(await screen.findByText(/What you'll learn/i)).toBeInTheDocument()
+    expect(screen.getByText('Declare a KEDA ScaledObject')).toBeInTheDocument()
+    expect(screen.getByText(/How it's implemented/i)).toBeInTheDocument()
+    expect(screen.getByText(/kind: ScaledObject/)).toBeInTheDocument()
+    expect(screen.getByText('keda-hpa-created')).toBeInTheDocument()
+    expect(screen.getByText(/hpa\/keda-hpa-go-api/)).toBeInTheDocument()
+  })
+})
+
+describe('Scenarios view — verify', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  const active: Scenario = { ...gitops, active: true }
+
+  it('is disabled while the scenario is inactive', async () => {
+    mockApi.listScenarios.mockResolvedValue([{ ...gitops }]) // inactive
+    renderScenarios()
+    const verifyBtn = await screen.findByRole('button', { name: /verify/i })
+    expect(verifyBtn).toBeDisabled()
+  })
+
+  it('runs the checks and renders the per-check pass/fail breakdown', async () => {
+    const user = userEvent.setup()
+    mockApi.listScenarios.mockResolvedValue([active])
+    mockApi.scenarioVerify.mockResolvedValue({
+      scenario: 'gitops-cicd',
+      passed: false,
+      results: [
+        { name: 'argocd-ready', type: 'kubectl', pass: true, got: '1', want: '>= 1' },
+        { name: 'app-synced', type: 'kubectl', pass: false, got: '0', want: '>= 1' },
+      ],
+    })
+
+    renderScenarios()
+    await user.click(await screen.findByRole('button', { name: /verify/i }))
+
+    await waitFor(() => expect(mockApi.scenarioVerify).toHaveBeenCalledWith('gitops-cicd'))
+    // Both checks render with their names and PASS/FAIL states.
+    expect(await screen.findByText('argocd-ready')).toBeInTheDocument()
+    expect(screen.getByText('app-synced')).toBeInTheDocument()
+    expect(screen.getByText('PASS')).toBeInTheDocument()
+    expect(screen.getByText('FAIL')).toBeInTheDocument()
   })
 })

--- a/src/ui/src/views/Scenarios.tsx
+++ b/src/ui/src/views/Scenarios.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from 'react'
 import { api } from '../api/client'
 import { qk } from '../lib/queryClient'
 import { useApiQuery } from '../hooks/useApiQuery'
-import type { Scenario, NotifyFn } from '../types'
+import type { Scenario, ScenarioParameter, ScenarioCheck, ScenarioVerifyResult, NotifyFn } from '../types'
 import { Badge } from '../components/Badge'
 import { ErrorState } from '../components/ErrorState'
 import { Icon } from '../components/Icon'
@@ -14,14 +14,27 @@ interface ScenariosProps {
   requestConfirm: (req: ConfirmRequest) => void
 }
 
+/** A snippet/component path is stored relative to the scenario's own directory
+ *  (e.g. "manifests/scaledobject.yaml"). Show it from the repo root instead —
+ *  "scenarios/<name>/manifests/scaledobject.yaml" — so a learner can find the
+ *  file directly. Paths already rooted at "scenarios/" are left untouched. */
+function repoPath(scenarioName: string, path: string): string {
+  return path.startsWith('scenarios/') ? path : `scenarios/${scenarioName}/${path}`
+}
+
 export function Scenarios({ notify, requestConfirm }: ScenariosProps) {
   const { data: scenarios = [], loading, loaded, loadError, refreshing, reload: load } = useApiQuery(qk.scenarios, api.listScenarios)
   const [filter, setFilter] = useState('')
   const [detail, setDetail] = useState<Scenario | null>(null)
   const [detailLoading, setDetailLoading] = useState(false)
   const { busy, run } = useJobRunner(notify)
+  const [verifying, setVerifying] = useState<Record<string, boolean>>({})
+  const [verifyResults, setVerifyResults] = useState<Record<string, ScenarioVerifyResult>>({})
   const modalCloseRef = useRef<HTMLButtonElement>(null)
   const detailOpener = useRef<Element | null>(null)
+  // Parameter values for the activation being confirmed, so onConfirm reads the
+  // latest edits from the dialog.
+  const activateParamsRef = useRef<Record<string, string>>({})
 
   // Modal: Esc to close, focus management
   useEffect(() => {
@@ -63,13 +76,23 @@ export function Scenarios({ notify, requestConfirm }: ScenariosProps) {
     const plat = s?.prerequisites?.platform ?? []
     const apps = s?.prerequisites?.apps ?? []
     const comps = s?.components ?? []
-    const doRun = () => run(name, `Activate ${name}`, () => api.scenarioUp(name), () => load())
+    const paramDefs = s?.parameters ?? []
+    // Seed the shared ref with each parameter's default; the form mutates it in
+    // place, and doRun submits whatever it holds at confirm time.
+    activateParamsRef.current = Object.fromEntries(paramDefs.map(p => [p.name, p.default]))
+    const doRun = () => run(name, `Activate ${name}`, () => api.scenarioUp(name, activateParamsRef.current), () => load())
     requestConfirm({
       title: `Activate ${s?.displayName || name}?`,
       danger: false,
       confirmLabel: 'Activate',
       message: (
         <div className="stack-3">
+          {paramDefs.length > 0 && (
+            <div>
+              <div className="field-label">Parameters <span className="hint-text">(tune these to experiment — defaults reproduce the standard scenario)</span></div>
+              <ParamForm parameters={paramDefs} valuesRef={activateParamsRef} />
+            </div>
+          )}
           {comps.length > 0 && (
             <div>
               <div className="field-label">This will install</div>
@@ -106,6 +129,27 @@ export function Scenarios({ notify, requestConfirm }: ScenariosProps) {
       confirmLabel: 'Deactivate',
       onConfirm: () => run(name, `Deactivate ${name}`, () => api.scenarioDown(name), () => load()),
     })
+  }
+
+  // Verify runs the scenario's checks and shows the per-check PASS/FAIL table
+  // (the CLI's `scenario verify` signal). Checks can fail while pods start, so a
+  // failure is surfaced as info, not an error.
+  async function verify(name: string) {
+    setVerifying(v => ({ ...v, [name]: true }))
+    try {
+      const res = await api.scenarioVerify(name)
+      setVerifyResults(r => ({ ...r, [name]: res }))
+      if (res.passed) {
+        notify('success', 'All checks passed', `${name} is in its expected state.`)
+      } else {
+        const failed = res.results.filter(c => !c.pass).length
+        notify('info', `${failed} of ${res.results.length} checks failing`, 'Checks can fail while pods are still starting — re-run in a moment to let them settle.')
+      }
+    } catch (e) {
+      notify('error', 'Verify failed', e instanceof Error ? e.message : String(e))
+    } finally {
+      setVerifying(v => ({ ...v, [name]: false }))
+    }
   }
 
   async function copyCmd(cmd: string) {
@@ -182,39 +226,50 @@ export function Scenarios({ notify, requestConfirm }: ScenariosProps) {
         ) : (
           <div className="card-body">
             {visible.map(s => (
-              <div key={s.name} className="scenario-row">
-                <div className="scenario-info">
-                  <div className="scenario-name">{s.displayName || s.name}</div>
-                  {s.description && (
-                    <div className="scenario-desc">
-                      {s.description.length > 120 ? s.description.slice(0, 120) + '…' : s.description}
+              <div key={s.name} className="scenario-item">
+                <div className="scenario-row">
+                  <div className="scenario-info">
+                    <div className="scenario-name">{s.displayName || s.name}</div>
+                    {s.description && (
+                      <div className="scenario-desc">
+                        {s.description.length > 120 ? s.description.slice(0, 120) + '…' : s.description}
+                      </div>
+                    )}
+                    <div className="scenario-tags">
+                      {s.category && <Badge variant="category">{s.category}</Badge>}
+                      {(s.runtimes || []).map(r => (
+                        <Badge key={r} variant="runtime">{r}</Badge>
+                      ))}
                     </div>
-                  )}
-                  <div className="scenario-tags">
-                    {s.category && <Badge variant="category">{s.category}</Badge>}
-                    {(s.runtimes || []).map(r => (
-                      <Badge key={r} variant="runtime">{r}</Badge>
-                    ))}
+                  </div>
+                  <Badge variant={s.active ? 'running' : 'stopped'}>{s.active ? 'Active' : 'Inactive'}</Badge>
+                  <div className="scenario-actions">
+                    <button
+                      className="btn btn-sm btn-primary"
+                      disabled={s.active || busy[s.name]}
+                      onClick={() => activate(s.name)}
+                    >
+                      {busy[s.name] ? 'Working…' : (<><Icon name="play" size={14} />Activate</>)}
+                    </button>
+                    <button
+                      className="btn btn-sm btn-danger"
+                      disabled={!s.active || busy[s.name]}
+                      onClick={() => deactivate(s.name)}
+                    >
+                      Deactivate
+                    </button>
+                    <button
+                      className="btn btn-sm"
+                      title={s.active ? 'Run the scenario’s checks and show the pass/fail breakdown' : 'Activate the scenario before verifying'}
+                      disabled={!s.active || verifying[s.name]}
+                      onClick={() => verify(s.name)}
+                    >
+                      {verifying[s.name] ? 'Verifying…' : (<><Icon name="check-circle" size={14} />Verify</>)}
+                    </button>
+                    <button className="btn btn-sm" onClick={() => openDetail(s.name)}>Details</button>
                   </div>
                 </div>
-                <Badge variant={s.active ? 'running' : 'stopped'}>{s.active ? 'Active' : 'Inactive'}</Badge>
-                <div className="scenario-actions">
-                  <button
-                    className="btn btn-sm btn-primary"
-                    disabled={s.active || busy[s.name]}
-                    onClick={() => activate(s.name)}
-                  >
-                    {busy[s.name] ? 'Working…' : (<><Icon name="play" size={14} />Activate</>)}
-                  </button>
-                  <button
-                    className="btn btn-sm btn-danger"
-                    disabled={!s.active || busy[s.name]}
-                    onClick={() => deactivate(s.name)}
-                  >
-                    Deactivate
-                  </button>
-                  <button className="btn btn-sm" onClick={() => openDetail(s.name)}>Details</button>
-                </div>
+                {verifyResults[s.name] && <CheckResults result={verifyResults[s.name]} />}
               </div>
             ))}
           </div>
@@ -246,6 +301,13 @@ export function Scenarios({ notify, requestConfirm }: ScenariosProps) {
                   </div>
                 )}
 
+                {detail.objectives && detail.objectives.length > 0 && (
+                  <div className="modal-section">
+                    <h3>What you'll learn</h3>
+                    <ul>{detail.objectives.map((o, i) => <li key={i}>{o}</li>)}</ul>
+                  </div>
+                )}
+
                 {detail.prerequisites && (
                   <div className="modal-section">
                     <h3>Prerequisites</h3>
@@ -274,11 +336,30 @@ export function Scenarios({ notify, requestConfirm }: ScenariosProps) {
                               <td>{c.name}</td>
                               <td><Badge variant="category">{c.type}</Badge></td>
                               <td className="td-muted">{c.namespace || 'default'}</td>
-                              <td className="td-muted">{c.chart || c.path || c.script || ''}</td>
+                              <td className="td-muted">{c.chart || (c.path ? repoPath(detail.name, c.path) : c.script) || ''}</td>
                             </tr>
                           ))}
                         </tbody>
                       </table>
+                    </div>
+                  </div>
+                )}
+
+                {detail.snippets && detail.snippets.length > 0 && (
+                  <div className="modal-section">
+                    <h3>How it's implemented</h3>
+                    <div className="stack-3">
+                      {detail.snippets.map(sn => (
+                        <div key={sn.label} className="snippet">
+                          <div className="snippet-head">
+                            <span className="snippet-label">{sn.label}</span>
+                            {sn.yaml && <button className="cmd-copy" onClick={() => copyCmd(sn.yaml!)}>Copy</button>}
+                          </div>
+                          {sn.description && <div className="snippet-desc">{sn.description}</div>}
+                          {sn.path && <div className="hint-text snippet-source">source: <code>{repoPath(detail.name, sn.path)}</code></div>}
+                          {sn.yaml && <pre className="snippet-code">{sn.yaml}</pre>}
+                        </div>
+                      ))}
                     </div>
                   </div>
                 )}
@@ -317,6 +398,35 @@ export function Scenarios({ notify, requestConfirm }: ScenariosProps) {
                   </div>
                 )}
 
+                {detail.checks && detail.checks.length > 0 && (
+                  <div className="modal-section">
+                    <h3>What "success" checks <span className="hint-text">(run these with Verify)</span></h3>
+                    <div className="table-scroll">
+                      <table className="data-table">
+                        <thead>
+                          <tr><th>Check</th><th>Type</th><th>Asserts</th></tr>
+                        </thead>
+                        <tbody>
+                          {detail.checks.map(c => (
+                            <tr key={c.name}>
+                              <td>{c.name}</td>
+                              <td><Badge variant="category">{c.type || 'check'}</Badge></td>
+                              <td className="td-muted"><code>{checkAssertion(c)}</code></td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                )}
+
+                {verifyResults[detail.name] && (
+                  <div className="modal-section">
+                    <h3>Verification</h3>
+                    <CheckResults result={verifyResults[detail.name]} />
+                  </div>
+                )}
+
                 <div className="card-footer">
                   <button
                     className="btn btn-primary"
@@ -332,6 +442,14 @@ export function Scenarios({ notify, requestConfirm }: ScenariosProps) {
                   >
                     Deactivate
                   </button>
+                  <button
+                    className="btn"
+                    disabled={!detail.active || verifying[detail.name]}
+                    title={detail.active ? 'Run the scenario’s checks' : 'Activate the scenario before verifying'}
+                    onClick={() => verify(detail.name)}
+                  >
+                    {verifying[detail.name] ? 'Verifying…' : 'Verify'}
+                  </button>
                   <button className="btn" onClick={closeDetail}>Close</button>
                 </div>
               </>
@@ -340,5 +458,90 @@ export function Scenarios({ notify, requestConfirm }: ScenariosProps) {
         </div>
       )}
     </>
+  )
+}
+
+/** Renders a check's assertion as a compact expression, e.g.
+ *  "deployment/keda-operator {.status.readyReplicas} >= 1". */
+function checkAssertion(c: ScenarioCheck): string {
+  const subject = c.type === 'promql' ? c.query : [c.resource, c.jsonpath].filter(Boolean).join(' ')
+  return [subject, c.operator, c.value].filter(Boolean).join(' ')
+}
+
+/** Renders an editable field per scenario parameter inside the Activate dialog.
+ *  Values are mirrored into valuesRef.current so the dialog's confirm closure
+ *  submits the latest edits. Integer params render as bounded number inputs. */
+function ParamForm({ parameters, valuesRef }: { parameters: ScenarioParameter[]; valuesRef: React.MutableRefObject<Record<string, string>> }) {
+  const [values, setValues] = useState<Record<string, string>>(() =>
+    Object.fromEntries(parameters.map(p => [p.name, p.default])),
+  )
+  function update(name: string, v: string) {
+    valuesRef.current = { ...valuesRef.current, [name]: v }
+    setValues(prev => ({ ...prev, [name]: v }))
+  }
+  return (
+    <div className="param-form">
+      {parameters.map(p => {
+        const id = `param-${p.name}`
+        const isInt = p.type === 'int'
+        return (
+          <div key={p.name} className="param-field">
+            <label htmlFor={id}>
+              {p.displayName || p.name}
+              {isInt && (p.min !== undefined || p.max !== undefined) && (
+                <span className="hint-text"> ({p.min ?? '−∞'}–{p.max ?? '∞'})</span>
+              )}
+            </label>
+            <input
+              id={id}
+              type={isInt ? 'number' : 'text'}
+              className="param-input"
+              value={values[p.name] ?? ''}
+              min={isInt ? p.min : undefined}
+              max={isInt ? p.max : undefined}
+              onChange={e => update(p.name, e.target.value)}
+            />
+            {p.description && <div className="field-help">{p.description}</div>}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+/** Renders the per-check PASS/FAIL breakdown from a scenario verify run, plus a
+ *  summary banner. Mirrors the CLI's `scenario verify` table so a browser-only
+ *  user gets the same signal: which checks hold, and why a failing one failed. */
+function CheckResults({ result }: { result: ScenarioVerifyResult }) {
+  const passed = result.results.filter(c => c.pass).length
+  const total = result.results.length
+  return (
+    <div className="verify-results" role="status" aria-live="polite">
+      <div className={`banner ${result.passed ? 'banner-success' : 'banner-warn'}`}>
+        <Icon name={result.passed ? 'check-circle' : 'alert-triangle'} size={16} className="banner-icon" />
+        <span className="banner-body">
+          {result.passed
+            ? <>All {total} checks passed — the scenario is in its expected state.</>
+            : <>{passed} of {total} checks passing. Checks can fail while pods are still starting — re-run in a moment.</>}
+        </span>
+      </div>
+      <div className="table-scroll">
+        <table className="data-table">
+          <thead>
+            <tr><th>Check</th><th>Result</th><th>Got</th><th>Want</th></tr>
+          </thead>
+          <tbody>
+            {result.results.map(c => (
+              <tr key={c.name}>
+                <td>{c.name}{c.type ? <span className="hint-text"> ({c.type})</span> : null}</td>
+                <td><Badge variant={c.pass ? 'running' : 'stopped'}>{c.pass ? 'PASS' : 'FAIL'}</Badge></td>
+                <td className="td-muted">{c.error ? <span className="verify-error">{c.error}</span> : (c.got || '—')}</td>
+                <td className="td-muted">{c.want || '—'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
   )
 }


### PR DESCRIPTION
## What this does

Remediates the "Autoscaling Under Load" UX audit and a follow-up round of platform, observability, application, and lab-reset UX fixes. 7 commits, ~67 files.

Closes #35
Closes #33

## Highlights

### Platform & component details
- Fix the component details view crashing with *"Cannot read properties of null (reading 'length')"* — Go nil slices serialized to JSON `null`; guaranteed non-nil arrays server-side + defensive guards in the UI.
- Install commands now resolve `$NAMESPACE` / `$DOMAIN_SUFFIX` / `$SCRIPT_DIR` / `$VALUES_FILE` inline and render a **variables legend** documenting every variable's value/meaning (secrets stay inline and are explained).
- Add a "Configuring Grafana" guide (login, pre-provisioned datasources + UIDs, dashboard provisioning).

### Observability
- **Application Request Metrics** and **Autoscaling Under Load** dashboards now return data — the cause was PromQL label bugs (`histogram_quantile(...)` missing `by (le)`; `status`/`job` vs the app's `app`/`code` labels), not a scrape gap. Pinned the Prometheus datasource UID in the baseline dashboards.
- Chaos Mesh dashboard exposed via a Traefik ingress at `chaos.<domain>` (added to the managed `/etc/hosts` block) instead of a broken `localhost:2333` link.

### Applications
- New **application details page**: project overview, tech stack, and the real Dockerfile + Helm values/Chart.yaml with in-repo paths.

### Scenarios
- Scenarios that self-install a platform tool (chaos-mesh, argocd, kyverno, cert-manager) now **declare it as a prerequisite**, so the dependency is listed and the platform component's "used in scenarios" reverse link resolves.
- Snippet/manifest source paths shown from the repo root.

### Lab reset
- **Reset now deactivates scenarios and incidents** (both `lab reset` and the top-level `labctl reset`), in proper order — previously their activation markers survived a teardown and read as active against a fresh cluster.
- Added a UI **"Reset lab"** button.
- **Learning progress** is kept across a lab reset and has its own separate reset control.

### Audit remediation (P0–P2), also included
- Grafana dashboard false-success (literal `{{.MonitoringNamespace}}` + swallowed error) fixed across affected scenarios.
- `app deploy` imports the local image into k3d/kind (no more ImagePullBackOff on a fresh cluster).
- HPA observability on the Apps view; verify-in-UI with a pass/fail table; user-tunable scenario parameters (validated before apply).
- Objectives / Checks now render in the scenario detail modal (#33).

## Testing
- `go build ./...`, `go test ./...` — green
- `labctl validate` — 13 scenarios valid
- `npm run build` (tsc -b + vite), 124 vitest — green
- `make cli-build` — green
- Observability, app-details, component-details, and reset changes verified live against a running k3d cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
