### PR TITLE
fix: backup-restore PV-data lesson, cost-right-sizing ingress/traffic hardening

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -273,6 +273,15 @@ default; override with the `PROMETHEUS_URL` environment variable.
 The REST equivalent is `POST /api/scenarios/{name}/verify` (synchronous,
 bounded to ~12s — use the CLI's `--watch` for long convergence).
 
+A check may declare a `remediation` hint and/or `pending: true` (see
+`docs/scenarios.md`). When a check fails, `verify` prints its remediation
+under a **Next step(s)** heading instead of the generic "a pod may still be
+starting" hint — which now appears only for a genuine failure that has no
+remediation of its own. A failing check marked `pending` renders as **PENDING**
+rather than **FAIL**: it means "you haven't done this drill step yet", so
+`verify` reports the scenario as incomplete (still non-zero exit) without the
+alarming "checks failed" wording.
+
 ---
 
 ### Content

--- a/docs/scenarios.md
+++ b/docs/scenarios.md
@@ -314,22 +314,36 @@ consumer running.
 **What it deploys:**
 - A `restore-marker` ConfigMap in the go-api namespace whose presence and value
   prove the backup/restore round-trip
+- A `data-writer` Deployment mounting a PVC (`restore-data`) that persists a
+  random `boot-id` on its PersistentVolume — so PV-data loss is **observable**,
+  not just described
 
 **Prerequisites:**
 - Apps: go-api
 - `jq` installed (used to scrub server-managed fields from the manifest archive)
 
-**Checks (5):** namespace exists, go-api running, restore marker present, marker
-value intact, **backup archive exists** (script).
+**Checks (7):** namespace exists, go-api running, data-writer running, restore
+PVC present, restore marker present, marker value intact, **backup archive
+exists** (script). The last four are marked `pending` — they render as PENDING
+(not FAIL) until you complete the matching drill step.
 
-**Run the drill:**
+**Run the drill (real `kubectl` — the commands you'd use on a live cluster):**
+- Note the PV data: `bash scenarios/backup-restore-drill/scripts/observe-pv-data.sh go-api`
 - Back up: `bash scenarios/backup-restore-drill/scripts/backup.sh go-api`
+  (read the script — it is `kubectl get … -o json | jq <scrub>`)
 - Simulate loss: `kubectl -n go-api delete configmap restore-marker`
-- Restore: `bash scenarios/backup-restore-drill/scripts/restore.sh go-api`
+- Restore: `kubectl apply --server-side --force-conflicts -f .labctl/backups/go-api-latest.json`
+  (`restore.sh` wraps this and also recreates the namespace if it was deleted)
 - Grade it: `labctl scenario verify backup-restore-drill`
+- **Harder:** `kubectl delete namespace go-api`, then
+  `bash scenarios/backup-restore-drill/scripts/restore.sh go-api`, then re-run
+  `observe-pv-data.sh` — the `boot-id` changed.
 
 > **Manifest-level backup:** archives round-trip Kubernetes objects, not
-> PersistentVolume data. For stateful data use a volume snapshot or Velero.
+> PersistentVolume data. Delete just the ConfigMap and the `boot-id` survives a
+> restore; delete the whole namespace and the PVC object comes back bound to a
+> brand-new empty volume — the object round-trips, the data does not. For
+> stateful data use a volume snapshot or Velero with restic.
 
 ---
 
@@ -338,12 +352,19 @@ value intact, **backup archive exists** (script).
 **Category:** cost
 
 **What it deploys:**
-- go-api re-deployed with 10× over-provisioned CPU (4000m) and 32× memory (1Gi)
-  via a Helm values override — the deliberate "before" state you observe in OpenCost
+- go-api's requests over-provisioned in place to 40× CPU (2000m) and 32× memory
+  (1Gi) via `kubectl set resources` — the deliberate "before" state you observe in
+  OpenCost. (The inflate mutates the running Deployment directly rather than via a
+  Helm upgrade, so it works no matter how go-api was deployed.)
 
 **Prerequisites:**
 - Platform: cost/opencost, monitoring/metrics, ingress
 - Apps: go-api
+
+> `cost/opencost` needs `monitoring/metrics` (Prometheus + kube-state-metrics) to
+> compute allocation — without it the OpenCost API returns no cost data. `scenario
+> up` warns if a platform prerequisite is missing and prints the `labctl platform
+> up <component>` command to install it.
 
 **Checks (5):** go-api running, **CPU request ≤ 100m** (script), **memory request
 ≤ 256Mi** (script), /health endpoint returns 200, OpenCost running.
@@ -351,10 +372,16 @@ value intact, **backup archive exists** (script).
 **The exercise:**
 
 1. `labctl scenario up cost-right-sizing` — inflates requests; checks **fail**
-2. `kubectl -n opencost port-forward svc/opencost 9090 &` — open the UI
-3. Observe inflated cost in OpenCost (go-api namespace)
-4. Right-size: `kubectl -n go-api set resources deployment go-api --requests=cpu=50m,memory=32Mi`
-5. `labctl scenario verify cost-right-sizing` — all checks **pass**
+2. `labctl traffic start --profile steady` — drive load (or the UI **Traffic** tab)
+   so "healthy under steady traffic" is exercised and usage shows up in OpenCost
+3. Open the OpenCost UI at **http://opencost.k3d.local** (OpenCost is exposed via
+   ingress). Run `sudo labctl hosts add` once to add `opencost.k3d.local` to
+   `/etc/hosts`. No ingress DNS entry? Fall back to
+   `kubectl -n opencost port-forward svc/opencost 9090 &` and open
+   `http://localhost:9090`.
+4. Observe inflated cost in OpenCost (go-api namespace)
+5. Right-size: `kubectl -n go-api set resources deployment go-api --requests=cpu=50m,memory=32Mi`
+6. `labctl scenario verify cost-right-sizing` — all checks **pass**
 
 > **k3d note:** no real billing API — OpenCost uses on-prem pricing defaults
 > (~$0.048/CPU-hr). Cost numbers are relative; the before/after contrast is real.
@@ -456,6 +483,9 @@ snippets:                              # applyable manifest fragments
       metadata:
         name: demo
         namespace: "{{.MonitoringNamespace}}"
+  - label: "Helm values (not a kubectl manifest)"
+    path: values/overprovisioned.yaml
+    apply: "helm upgrade -f -  (or translate to 'kubectl set resources')"
 ```
 
 - A `reference` needs a `label` and an `http(s)` `url`; `note` is optional.
@@ -466,6 +496,10 @@ snippets:                              # applyable manifest fragments
 - Snippet bodies are template-resolved, so a `path` snippet can reuse the same
   manifest the engine applies, and an inline `yaml` snippet can reference
   `{{.MonitoringNamespace}}` etc. — it prints ready to `kubectl apply -f -`.
+- `apply` (optional) overrides the per-snippet "apply with" hint. It defaults to
+  `kubectl apply -f -`; set it when the snippet is **not** a kubectl manifest
+  (e.g. a Helm values file) so the learner isn't told to `kubectl apply` something
+  that isn't appliable.
 
 ### Template Variables
 
@@ -533,7 +567,17 @@ checks:                              # machine-verifiable assertions
     type: script                     # exit 0 = pass; runs with DOMAIN_SUFFIX,
     script: checks/custom.sh         # MONITORING_NAMESPACE, PROJECT_ROOT set
     timeoutSeconds: 60               # any check may override the 30s default
+    remediation: "run the fix: …"    # optional: shown under a failing check
+    pending: true                    # optional: render PENDING (not FAIL) until
+                                     # the user performs the matching drill step
 ```
+
+**`remediation` / `pending`** make `verify` teach instead of alarm. A failing
+check with a `remediation` prints that fix under a **Next step(s)** heading; the
+generic "a pod may still be starting / --watch" hint is shown only for a genuine
+failure that has no remediation. A failing `pending` check renders **PENDING**
+and is reported as an incomplete drill step, so "you haven't run the backup yet"
+never reads as "the scenario is broken".
 
 Rules (enforced at load time — an invalid scenario refuses to load and CI
 fails on it):

--- a/platform/cost/opencost/install.sh
+++ b/platform/cost/opencost/install.sh
@@ -17,19 +17,34 @@ NAMESPACE="opencost"
 CHART_VERSION="${OPENCOST_CHART_VERSION:-1.43.2}"
 MONITORING_NS="${MONITORING_NAMESPACE:-monitoring}"
 PROMETHEUS_SVC="${PROMETHEUS_SVC:-http://prometheus-kube-prometheus-prometheus.${MONITORING_NS}.svc:9090}"
+# DOMAIN_SUFFIX is provided by the executor environment (from .env + runtime.env);
+# it drives the OpenCost UI ingress host (opencost.<DOMAIN_SUFFIX>).
+DOMAIN_SUFFIX="${DOMAIN_SUFFIX:-k3d.local}"
+INGRESS_HOST="opencost.${DOMAIN_SUFFIX}"
 
 echo "Installing OpenCost ${CHART_VERSION} (namespace=${NAMESPACE})..."
 
 helm repo add opencost https://opencost.github.io/opencost-helm-chart --force-update
 helm repo update opencost
 
+# Point OpenCost at the in-cluster Prometheus. Setting external.url ALONE is not
+# enough: the opencost chart only honours external.url when external.enabled=true
+# (otherwise it builds PROMETHEUS_SERVER_ENDPOINT from its internal defaults —
+# prometheus-server.prometheus-system — which does not exist in this lab and
+# leaves OpenCost unable to compute any allocation). Enable external and disable
+# internal so the endpoint we pass is the one the pod actually queries.
 helm upgrade --install opencost opencost/opencost \
   --namespace "$NAMESPACE" \
   --create-namespace \
   --version "$CHART_VERSION" \
   -f "$SCRIPT_DIR/values.yaml" \
   --set "opencost.exporter.defaultClusterId=lab-cluster" \
+  --set "opencost.prometheus.internal.enabled=false" \
+  --set "opencost.prometheus.external.enabled=true" \
   --set "opencost.prometheus.external.url=${PROMETHEUS_SVC}" \
+  --set "opencost.ui.ingress.enabled=true" \
+  --set "opencost.ui.ingress.hosts[0].host=${INGRESS_HOST}" \
+  --set "opencost.ui.ingress.hosts[0].paths[0]=/" \
   --wait --timeout 5m
 
 echo "Waiting for OpenCost to be ready..."
@@ -37,6 +52,8 @@ kubectl rollout status deployment/opencost -n "$NAMESPACE" --timeout=120s
 
 echo ""
 echo "OpenCost installed."
-echo "  UI (port-forward fallback): kubectl -n ${NAMESPACE} port-forward svc/opencost 9090 &"
-echo "  If ingress is up: http://opencost.\${DOMAIN_SUFFIX:-k3d.local}"
+echo "  UI (ingress): http://${INGRESS_HOST}"
+echo "    Add the DNS entry once with: sudo labctl hosts add   (edits /etc/hosts)"
+echo "  UI (port-forward fallback, if the hosts entry isn't added):"
+echo "    kubectl -n ${NAMESPACE} port-forward svc/opencost 9090 &   then open http://localhost:9090"
 echo "  NOTE: k3d has no real billing — OpenCost uses on-prem default pricing (~\$0.048/CPU-hr)."

--- a/platform/cost/opencost/values.yaml
+++ b/platform/cost/opencost/values.yaml
@@ -28,8 +28,15 @@ opencost:
         cpu: 100m
         memory: 64Mi
 
-  # Ingress is intentionally off by default. Enable with:
-  #   COST_PROVIDER=opencost labctl platform up cost
-  # and access via port-forward, or set ingress.enabled=true with your domain.
-  ingress:
-    enabled: false
+    # Expose the OpenCost UI through the cluster ingress so it is reachable at
+    # http://opencost.<domain> without a port-forward. NOTE: the ingress config
+    # lives under opencost.ui.ingress (not opencost.ingress) — that is where the
+    # chart reads it; a top-level opencost.ingress block is silently ignored.
+    # install.sh overrides the host with the real DOMAIN_SUFFIX at install time.
+    ingress:
+      enabled: true
+      ingressClassName: traefik
+      hosts:
+        - host: opencost.k3d.local
+          paths:
+            - /

--- a/scenarios/backup-restore-drill/manifests/stateful.yaml
+++ b/scenarios/backup-restore-drill/manifests/stateful.yaml
@@ -1,0 +1,76 @@
+# Stateful component for the backup/restore drill. This is what turns the drill's
+# headline lesson — "a manifest backup round-trips Kubernetes OBJECTS, not
+# PersistentVolume DATA" — from a tip into something you can watch happen.
+#
+# The data-writer Deployment mounts a PVC and, on first boot, writes a random
+# boot-id into the volume at /data/boot-id. Read it with observe-pv-data.sh.
+#
+#   - Delete just the restore-marker ConfigMap and restore → boot-id is UNCHANGED
+#     (the volume was never touched; full recovery).
+#   - Delete the whole namespace and restore → the PVC OBJECT comes back from the
+#     backup, but bound to a brand-new empty volume, so the writer generates a
+#     DIFFERENT boot-id. The object round-tripped; the data did not. That is the
+#     exact failure mode this drill exists to rehearse.
+#
+# The image is the go-api image already imported into the cluster (alpine-based,
+# so it has a shell); imagePullPolicy: Never keeps activation offline and fast.
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: restore-data
+  namespace: go-api
+  labels:
+    app.kubernetes.io/part-of: backup-restore-drill
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: data-writer
+  namespace: go-api
+  labels:
+    app.kubernetes.io/part-of: backup-restore-drill
+    app: data-writer
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: data-writer
+  template:
+    metadata:
+      labels:
+        app: data-writer
+        app.kubernetes.io/part-of: backup-restore-drill
+    spec:
+      containers:
+        - name: writer
+          image: go-api:latest
+          imagePullPolicy: Never
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              if [ ! -f /data/boot-id ]; then
+                head -c 16 /dev/urandom | od -An -tx1 | tr -d ' \n' > /data/boot-id
+              fi
+              echo "data-writer up — boot-id=$(cat /data/boot-id) (persisted on the PV at /data)"
+              exec tail -f /dev/null
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: restore-data

--- a/scenarios/backup-restore-drill/scenario.yaml
+++ b/scenarios/backup-restore-drill/scenario.yaml
@@ -2,7 +2,7 @@ apiVersion: scenario.snowops.net/v2
 name: backup-restore-drill
 verified: true
 displayName: "Day-2 Drill: Namespace Backup & Restore"
-description: "Back up a namespace's resources to a manifest archive, simulate accidental data loss (delete a resource — or the whole namespace), then restore from the backup and verify the round-trip with checks. A dependency-light alternative to Velero that teaches the backup/restore loop every operator must rehearse before they need it."
+description: "Back up a namespace's resources to a manifest archive, simulate accidental data loss (delete a resource — or the whole namespace), then restore from the backup and verify the round-trip with checks. A stateful data-writer on a PersistentVolume makes the crucial lesson concrete: the manifest backup round-trips Kubernetes OBJECTS, not the DATA on a volume. A dependency-light alternative to Velero that teaches the backup/restore loop every operator must rehearse before they need it."
 category: operations
 prerequisites:
   apps:
@@ -13,9 +13,9 @@ runtimes:
 
 objectives:
   - "Capture a namespace's resources into a restorable manifest archive"
-  - "Simulate accidental loss by deleting a resource (or the namespace)"
+  - "Simulate accidental loss by deleting a resource (or the whole namespace)"
   - "Restore from the backup and verify the namespace round-trips intact"
-  - "Understand what a manifest-export backup covers and what it does not (PV data)"
+  - "See first-hand what a manifest-export backup covers (objects) and what it does NOT (PV data): delete the namespace, restore, and watch the data-writer's boot-id change"
 
 stages:
   - name: baseline
@@ -24,6 +24,12 @@ stages:
       - name: restore-marker
         type: manifest
         path: manifests/baseline.yaml
+  - name: stateful
+    description: Deploy a data-writer that persists a boot-id on a PersistentVolume, so PV-data loss is observable
+    components:
+      - name: data-writer
+        type: manifest
+        path: manifests/stateful.yaml
 
 checks:
   - name: go-api-namespace-exists
@@ -38,10 +44,27 @@ checks:
     operator: ">="
     value: "1"
 
+  - name: data-writer-running
+    type: kubectl
+    resource: deployment/data-writer
+    namespace: go-api
+    jsonpath: "{.status.readyReplicas}"
+    operator: ">="
+    value: "1"
+
+  - name: restore-data-pvc-present
+    type: kubectl
+    resource: persistentvolumeclaim/restore-data
+    namespace: go-api
+    pending: true
+    remediation: "Restore from the backup: kubectl apply --server-side --force-conflicts -f .labctl/backups/go-api-latest.json (or bash scenarios/backup-restore-drill/scripts/restore.sh go-api)"
+
   - name: restore-marker-present
     type: kubectl
     resource: configmap/restore-marker
     namespace: go-api
+    pending: true
+    remediation: "Restore from the backup: kubectl apply --server-side --force-conflicts -f .labctl/backups/go-api-latest.json (or bash scenarios/backup-restore-drill/scripts/restore.sh go-api)"
 
   - name: restore-marker-value-intact
     type: kubectl
@@ -50,34 +73,56 @@ checks:
     jsonpath: "{.data.canary}"
     operator: "=="
     value: "do-not-delete"
+    pending: true
+    remediation: "Restore from the backup: kubectl apply --server-side --force-conflicts -f .labctl/backups/go-api-latest.json (or bash scenarios/backup-restore-drill/scripts/restore.sh go-api)"
 
   - name: backup-archive-exists
     type: script
     script: scripts/check-backup-exists.sh
+    pending: true
+    remediation: "Take a backup first: bash scenarios/backup-restore-drill/scripts/backup.sh go-api"
 
 snippets:
   - label: "The restore canary this drill backs up"
     description: "A ConfigMap in the go-api namespace acting as the canary: the drill backs it up, deletes it, then restores it. If its value survives the round-trip, the restore worked."
     path: manifests/baseline.yaml
+  - label: "backup.sh — read what a manifest backup actually is"
+    description: "The backup is a real 'kubectl get … -o json | jq <scrub> > archive' pipeline. Read it: this is the command you'd run (or adapt) on any cluster — no labctl magic. It scrubs server-managed fields and a PVC's volume binding so the manifests re-apply cleanly."
+    path: scripts/backup.sh
+  - label: "restore.sh — restore is just kubectl apply"
+    description: "Restore is 'kubectl apply --server-side --force-conflicts -f archive', plus a namespace-recreate if the whole namespace was deleted. Read it so you know exactly what a restore does to the cluster."
+    path: scripts/restore.sh
 
 explore:
   commands:
-    - label: "1. Back up the go-api namespace to a manifest archive"
+    # These are the REAL commands an operator runs on a live cluster — the drill
+    # teaches kubectl, not labctl. labctl's only role is verify (grading) and
+    # activate/teardown (the simulator's own orchestration).
+    - label: "1. Note the PV data before you start (remember this boot-id)"
+      command: "bash {{.ProjectRoot}}/scenarios/backup-restore-drill/scripts/observe-pv-data.sh go-api"
+    - label: "2. Back up the namespace — run the tool, then read it: it's 'kubectl get -o json | jq'"
       command: "bash {{.ProjectRoot}}/scenarios/backup-restore-drill/scripts/backup.sh go-api"
-    - label: "2. Simulate accidental loss (delete the restore marker)"
+    - label: "3. Simulate accidental loss (delete the restore marker with kubectl)"
       command: "kubectl -n go-api delete configmap restore-marker"
-    - label: "3. Confirm the loss — this check now fails"
+    - label: "4. Confirm the loss — the marker checks now show as PENDING"
       command: "labctl scenario verify backup-restore-drill"
-    - label: "4. Restore from the backup archive"
+    - label: "5. Restore with kubectl — server-side apply the backup archive"
+      command: "kubectl apply --server-side --force-conflicts -f .labctl/backups/go-api-latest.json"
+    - label: "6. Verify the round-trip — checks pass again"
+      command: "labctl scenario verify backup-restore-drill"
+    - label: "7. HARDER: delete the whole namespace with kubectl"
+      command: "kubectl delete namespace go-api"
+    - label: "8. Restore it — restore.sh recreates the namespace first, then applies the archive"
       command: "bash {{.ProjectRoot}}/scenarios/backup-restore-drill/scripts/restore.sh go-api"
-    - label: "5. Verify the round-trip — checks pass again"
-      command: "labctl scenario verify backup-restore-drill"
+    - label: "9. Re-check the PV data — the boot-id CHANGED: the object came back, the data did not"
+      command: "bash {{.ProjectRoot}}/scenarios/backup-restore-drill/scripts/observe-pv-data.sh go-api"
     - label: "Inspect the backup archive"
       command: "ls -la .labctl/backups/ && cat .labctl/backups/go-api-latest.json"
   tips:
-    - "Run backup.sh BEFORE the destructive step — you cannot restore what you never captured."
-    - "This is a manifest-level backup: it round-trips Kubernetes objects (Deployments, Services, ConfigMaps, Secrets), NOT PersistentVolume data. For stateful data use a volume snapshot or Velero with restic."
-    - "The backup strips server-managed fields (resourceVersion, uid, status) so the manifests re-apply cleanly into the same or a fresh namespace."
-    - "Try the harder variant: 'kubectl delete namespace go-api' then restore — the archive recreates the namespace and all its objects."
+    - "The commands here are real kubectl/jq — the ones you'd use on any cluster. Read backup.sh and restore.sh (in Snippets): the backup is 'kubectl get -o json | jq <scrub>', the restore is 'kubectl apply --server-side -f archive'. labctl only grades (verify) and stands the lab up/down."
+    - "Run the backup BEFORE the destructive step — you cannot restore what you never captured."
+    - "This is a manifest-level backup: it round-trips Kubernetes objects (Deployments, Services, ConfigMaps, Secrets, the PVC object), NOT the DATA on a PersistentVolume. The data-writer's boot-id proves it: it survives a ConfigMap delete, but a namespace delete gives you a brand-new empty volume. For stateful data use a volume snapshot or Velero with restic."
+    - "The backup strips server-managed fields (resourceVersion, uid, status) and a PVC's volume binding (spec.volumeName) so the manifests re-apply cleanly into the same or a fresh namespace."
+    - "Restore uses server-side apply (kubectl apply --server-side), so it is quiet — no 'last-applied-configuration' warnings — and idempotent: re-running over a healthy namespace is a no-op."
     - "Archives are written to .labctl/backups/ (gitignored runtime state). go-api-latest.json always points at the most recent backup."
-    - "Tear down with 'labctl scenario down backup-restore-drill' — removes the restore marker; go-api stays running."
+    - "Tear down with 'labctl scenario down backup-restore-drill' — removes the restore marker and data-writer; go-api stays running."

--- a/scenarios/backup-restore-drill/scripts/backup.sh
+++ b/scenarios/backup-restore-drill/scripts/backup.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 
 NS="${1:?Usage: backup.sh <namespace>}"
 BACKUP_DIR="${BACKUP_DIR:-.labctl/backups}"
-RESOURCES="${RESOURCES:-deployment,service,configmap,secret,serviceaccount,ingress,pdb,horizontalpodautoscaler}"
+RESOURCES="${RESOURCES:-deployment,service,configmap,secret,serviceaccount,ingress,pdb,horizontalpodautoscaler,persistentvolumeclaim}"
 
 if ! command -v jq >/dev/null 2>&1; then
   echo "ERROR: 'jq' is required to scrub manifests but was not found." >&2
@@ -62,6 +62,19 @@ kubectl get "$RESOURCES" -n "$NS" -o json 2>/dev/null |
             .status
           )
           | if .kind == "Service" then del(.spec.clusterIP, .spec.clusterIPs) else . end
+          # A PVC backup captures the CLAIM, not the volume it was bound to. Drop
+          # the binding (spec.volumeName + the binder annotations) so a restore
+          # provisions a fresh, EMPTY volume instead of dangling on a PV that no
+          # longer exists. This is the crux of the drill: the object round-trips,
+          # the data does not.
+          | if .kind == "PersistentVolumeClaim" then
+              del(.spec.volumeName,
+                  .metadata.annotations."pv.kubernetes.io/bind-completed",
+                  .metadata.annotations."pv.kubernetes.io/bound-by-controller",
+                  .metadata.annotations."volume.kubernetes.io/selected-node",
+                  .metadata.annotations."volume.beta.kubernetes.io/storage-provisioner",
+                  .metadata.annotations."volume.kubernetes.io/storage-provisioner")
+            else . end
         )
       | {apiVersion: "v1", kind: "List", items: .}
     ' >"$ARCHIVE"

--- a/scenarios/backup-restore-drill/scripts/check-backup-exists.sh
+++ b/scenarios/backup-restore-drill/scripts/check-backup-exists.sh
@@ -21,12 +21,13 @@ fi
 
 # Surface the backup's state — how many objects it holds and how old it is — so
 # a passing check tells the operator *what* they would restore, not just that a
-# file exists. Age uses stat in a portable (BSD/GNU) way; both are best-effort.
+# file exists. Age uses `date -r <file>` (unlike `stat`, its flags agree
+# between BSD and GNU) and is best-effort.
 COUNT="?"
 if command -v jq >/dev/null 2>&1; then
   COUNT=$(jq '.items | length' "$LATEST" 2>/dev/null || echo "?")
 fi
-MTIME=$(stat -f %m "$LATEST" 2>/dev/null || stat -c %Y "$LATEST" 2>/dev/null || echo "")
+MTIME=$(date -r "$LATEST" +%s 2>/dev/null || echo "")
 AGE=""
 if [ -n "$MTIME" ]; then
   NOW=$(date -u +%s)

--- a/scenarios/backup-restore-drill/scripts/check-backup-exists.sh
+++ b/scenarios/backup-restore-drill/scripts/check-backup-exists.sh
@@ -19,4 +19,23 @@ if [ ! -f "$LATEST" ]; then
   exit 1
 fi
 
-echo "OK: backup archive present (${LATEST})."
+# Surface the backup's state — how many objects it holds and how old it is — so
+# a passing check tells the operator *what* they would restore, not just that a
+# file exists. Age uses stat in a portable (BSD/GNU) way; both are best-effort.
+COUNT="?"
+if command -v jq >/dev/null 2>&1; then
+  COUNT=$(jq '.items | length' "$LATEST" 2>/dev/null || echo "?")
+fi
+MTIME=$(stat -f %m "$LATEST" 2>/dev/null || stat -c %Y "$LATEST" 2>/dev/null || echo "")
+AGE=""
+if [ -n "$MTIME" ]; then
+  NOW=$(date -u +%s)
+  SECS=$((NOW - MTIME))
+  if [ "$SECS" -lt 90 ]; then
+    AGE=", taken ${SECS}s ago"
+  else
+    AGE=", taken $((SECS / 60))m ago"
+  fi
+fi
+
+echo "OK: backup archive present — ${COUNT} object(s)${AGE} (${LATEST})."

--- a/scenarios/backup-restore-drill/scripts/observe-pv-data.sh
+++ b/scenarios/backup-restore-drill/scripts/observe-pv-data.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# observe-pv-data.sh [namespace] — print the boot-id the data-writer persisted on
+# its PersistentVolume. Run it at each step of the drill to watch what a
+# manifest backup does and does NOT protect:
+#
+#   before backup      -> boot-id: A
+#   delete configmap   -> boot-id: A   (PV untouched)
+#   restore            -> boot-id: A   (full recovery)
+#   delete NAMESPACE   -> (pod gone)
+#   restore            -> boot-id: B   (PVC object restored, but the volume — and
+#                                       the data on it — is brand new: DATA LOST)
+#
+# This is the point of the drill: the ConfigMap round-trips, the PV data does not.
+
+NS="${1:-go-api}"
+
+if ! kubectl -n "$NS" get deploy data-writer >/dev/null 2>&1; then
+  echo "data-writer is not deployed in '${NS}'." >&2
+  echo "Activate the scenario first: labctl scenario up backup-restore-drill --deploy-prereqs" >&2
+  exit 1
+fi
+
+POD=$(kubectl -n "$NS" get pod -l app=data-writer -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+if [ -z "$POD" ]; then
+  echo "No data-writer pod is running in '${NS}' yet — the volume's data is unavailable." >&2
+  echo "If you just deleted the namespace, restore first, then re-run this." >&2
+  exit 1
+fi
+
+BOOT_ID=$(kubectl -n "$NS" exec "$POD" -- sh -c 'cat /data/boot-id 2>/dev/null' || true)
+if [ -z "$BOOT_ID" ]; then
+  echo "PV present but no boot-id yet (writer still starting). Re-run in a moment."
+  exit 0
+fi
+
+echo "PV data boot-id: ${BOOT_ID}"
+echo "(If this value changed after a restore, the PV data was LOST — a manifest"
+echo " backup restores the PVC object, not the bytes that were on the volume.)"

--- a/scenarios/backup-restore-drill/scripts/restore.sh
+++ b/scenarios/backup-restore-drill/scripts/restore.sh
@@ -6,10 +6,23 @@ set -euo pipefail
 # every captured object. Idempotent: re-running over a healthy namespace is a
 # no-op apply.
 #
+# We restore with server-side apply (--server-side --force-conflicts) rather than
+# the default client-side apply. The archive deliberately strips the
+# kubectl.kubernetes.io/last-applied-configuration annotation, which client-side
+# apply warns loudly about on every object ("resource … is missing the
+# annotation … will be patched automatically"). Those warnings look like errors
+# and erode trust in a restore that actually succeeded. Server-side apply does
+# not depend on that annotation, so the restore is quiet and we print our own
+# object-count summary instead.
+#
 # Env:
 #   BACKUP_DIR  where archives live (default: .labctl/backups)
 
-NS="${1:?Usage: restore.sh <namespace> [archive.json]}"
+if [ $# -lt 1 ]; then
+  echo "Usage: restore.sh <namespace> [archive.json]" >&2
+  exit 1
+fi
+NS="$1"
 BACKUP_DIR="${BACKUP_DIR:-.labctl/backups}"
 ARCHIVE="${2:-${BACKUP_DIR}/${NS}-latest.json}"
 
@@ -19,15 +32,23 @@ if [ ! -f "$ARCHIVE" ]; then
   exit 1
 fi
 
+OBJECTS="unknown number of"
+if command -v jq >/dev/null 2>&1; then
+  OBJECTS=$(jq '.items | length' "$ARCHIVE" 2>/dev/null || echo "unknown number of")
+fi
+
 # Recreate the namespace if the loss simulation deleted it.
 if ! kubectl get namespace "$NS" >/dev/null 2>&1; then
   echo "==> Namespace '${NS}' is gone — recreating it"
   kubectl create namespace "$NS"
 fi
 
-echo "==> Restoring '${NS}' from ${ARCHIVE}"
-kubectl apply -n "$NS" -f "$ARCHIVE"
+echo "==> Restoring '${NS}' from ${ARCHIVE} (${OBJECTS} object(s))"
+# Server-side apply keeps the output clean (no last-applied-configuration
+# warnings) and converges cleanly whether the namespace is fresh or drifted.
+kubectl apply --server-side --force-conflicts -n "$NS" -f "$ARCHIVE"
 
 echo ""
-echo "Restore complete. Verify the round-trip:"
+echo "Restored ${OBJECTS} object(s) into '${NS}'."
+echo "Verify the round-trip:"
 echo "  labctl scenario verify backup-restore-drill"

--- a/scenarios/cost-right-sizing/scenario.yaml
+++ b/scenarios/cost-right-sizing/scenario.yaml
@@ -23,11 +23,14 @@ objectives:
 
 stages:
   - name: inflate
-    description: Re-deploy go-api with 10x over-provisioned CPU and memory requests (the 'before' state to observe in OpenCost)
+    description: Over-provision go-api's CPU/memory requests 40×/32× (the 'before' state to observe in OpenCost)
     components:
-      # A script (not a bare helm component) because we upgrade the EXISTING
-      # go-api Helm release in place — a separate release cannot adopt the
-      # go-api namespace/Deployment that `app deploy go-api` already owns.
+      # A script (not a bare helm component) because we mutate the EXISTING
+      # go-api Deployment in place with `kubectl set resources` — the exact
+      # inverse of the right-sizing fix. This is robust no matter how go-api was
+      # deployed (helm, kubectl apply, or the kind-e2e bootstrap); an earlier
+      # `helm upgrade` approach broke with server-side-apply field conflicts
+      # whenever go-api was not owned by helm.
       - name: go-api-overprovisioned
         type: script
         script: scripts/inflate.sh
@@ -66,17 +69,24 @@ snippets:
   - label: "The over-provisioned 'before' state (40× CPU, 32× memory)"
     description: "go-api's deliberately inflated resource requests. This is the waste OpenCost surfaces — right-size these requests, re-deploy, and verify the cost drops."
     path: values/overprovisioned.yaml
+    # This is a Helm VALUES file, not a kubectl manifest — it cannot be piped to
+    # `kubectl apply`. Reproduce the 'before' state directly instead:
+    apply: "kubectl -n go-api set resources deployment go-api --requests=cpu=2000m,memory=1Gi --limits=cpu=2000m,memory=1Gi  (Helm values reference — not kubectl-appliable)"
 
 explore:
   urls:
-    - label: "OpenCost UI — per-namespace cost breakdown"
-      url: "http://localhost:9090 (port-forward first — see commands below)"
+    - label: "OpenCost UI — per-namespace cost breakdown (via ingress)"
+      url: "http://opencost.{{.DomainSuffix}}"
     - label: "Grafana — go-api resource usage vs requests"
       url: "http://grafana.{{.DomainSuffix}}/d/pod-resources"
   commands:
-    - label: "0. Open the OpenCost UI (run in background)"
+    - label: "0. Add the ingress DNS entries once (opencost.{{.DomainSuffix}} etc.) to /etc/hosts, then open http://opencost.{{.DomainSuffix}}"
+      command: "sudo labctl hosts add"
+    - label: "0b. FALLBACK only if you haven't run 'labctl hosts add' — port-forward the UI instead, then open http://localhost:9090"
       command: "kubectl -n opencost port-forward svc/opencost 9090 &"
-    - label: "1. Confirm the inflated state — checks fail while over-provisioned"
+    - label: "1a. Drive steady traffic so 'healthy under load' is actually exercised (also warms the ingress route)"
+      command: "labctl traffic start --profile steady --rps 10"
+    - label: "1b. Confirm the inflated state — checks fail while over-provisioned"
       command: "labctl scenario verify cost-right-sizing"
     - label: "2. Right-size go-api with kubectl set resources"
       command: "kubectl -n go-api set resources deployment go-api --requests=cpu=50m,memory=32Mi --limits=cpu=200m,memory=128Mi"
@@ -84,11 +94,16 @@ explore:
       command: "kubectl -n go-api rollout status deployment go-api"
     - label: "4. Verify the right-sized state — all checks pass"
       command: "labctl scenario verify cost-right-sizing"
-    - label: "5. Observe the cost difference in OpenCost (wait ~1 min for a new data point)"
+    - label: "5. Observe the cost difference in OpenCost at http://opencost.{{.DomainSuffix}} (wait ~1 min for a new data point). No ingress DNS entry yet? Fall back to the port-forward below."
       command: "kubectl -n opencost port-forward svc/opencost 9090 &"
     - label: "Inspect the current CPU request"
       command: "kubectl -n go-api get deploy go-api -o jsonpath='{.spec.template.spec.containers[0].resources}'"
+    - label: "6. Stop the load generator when you're done"
+      command: "labctl traffic stop"
   tips:
+    - "OpenCost is exposed via ingress at http://opencost.{{.DomainSuffix}}. Run 'sudo labctl hosts add' once to add opencost.{{.DomainSuffix}} (and the other lab hostnames) to /etc/hosts — it manages a block between '# BEGIN snowops-labs' and '# END snowops-labs' and re-execs itself with sudo since /etc/hosts is root-owned. If you'd rather not touch /etc/hosts, use the port-forward fallback (command 0b) and browse http://localhost:9090 instead."
+    - "Generate load first (step 1a, or the UI 'Traffic' tab → start the 'steady' profile). It exercises the 'healthy under steady traffic' objective and makes go-api's real usage visible in Grafana/OpenCost — the low-usage-vs-high-request gap is the whole point."
+    - "The first request through the ingress after a rollout can take a few seconds (cold Traefik route + pod warm-up) — the health check is not hung. Running traffic keeps the route warm."
     - "Grafana → the linked Pod Resources dashboard: compare the flat 'requests' line against the much lower 'usage' line — that gap is the waste. After right-sizing, requests should drop toward actual usage."
     - "OpenCost uses on-prem pricing defaults in k3d (~$0.048/CPU-hr, ~$0.006/GB-hr). Numbers are relative — useful for comparing before vs after, not real invoices."
     - "Requests drive Kubernetes scheduling and cloud node billing. Limits cap container usage but don't affect node cost. Right-sizing requests is where the savings are."

--- a/scenarios/cost-right-sizing/scripts/check-cpu-request.sh
+++ b/scenarios/cost-right-sizing/scripts/check-cpu-request.sh
@@ -9,14 +9,31 @@ set -euo pipefail
 
 NAMESPACE="${NAMESPACE:-go-api}"
 APP="${APP:-go-api}"
+CONTAINER="${CONTAINER:-$APP}" # container to inspect (defaults to the app name)
 MAX_CPU_MILLICORES=100 # threshold in millicores
 
+# Distinguish "deployment not found" from "request not set" so the message
+# points at the real cause instead of always blaming a missing deployment.
+if ! kubectl get deployment "$APP" -n "$NAMESPACE" >/dev/null 2>&1; then
+  echo "FAIL: deployment ${NAMESPACE}/${APP} not found — deploy it first (labctl app deploy ${APP})." >&2
+  exit 1
+fi
+
+# Read the named container's CPU request (works for multi-container pods),
+# falling back to the first container if no container matches CONTAINER.
 raw=$(kubectl get deployment "$APP" -n "$NAMESPACE" \
-  -o jsonpath='{.spec.template.spec.containers[0].resources.requests.cpu}' \
+  -o jsonpath="{.spec.template.spec.containers[?(@.name==\"$CONTAINER\")].resources.requests.cpu}" \
   2>/dev/null || true)
+if [ -z "$raw" ]; then
+  raw=$(kubectl get deployment "$APP" -n "$NAMESPACE" \
+    -o jsonpath='{.spec.template.spec.containers[0].resources.requests.cpu}' \
+    2>/dev/null || true)
+fi
 
 if [ -z "$raw" ]; then
-  echo "FAIL: could not read CPU request from ${NAMESPACE}/${APP}. Is the deployment running?" >&2
+  echo "FAIL: no CPU request set on ${NAMESPACE}/${APP} (container '${CONTAINER}')." >&2
+  echo "A missing request means the pod is scheduled with no CPU reservation — set one to right-size:" >&2
+  echo "  kubectl -n ${NAMESPACE} set resources deployment ${APP} --requests=cpu=50m,memory=32Mi" >&2
   exit 1
 fi
 

--- a/scenarios/cost-right-sizing/scripts/check-memory-request.sh
+++ b/scenarios/cost-right-sizing/scripts/check-memory-request.sh
@@ -9,14 +9,31 @@ set -euo pipefail
 
 NAMESPACE="${NAMESPACE:-go-api}"
 APP="${APP:-go-api}"
+CONTAINER="${CONTAINER:-$APP}" # container to inspect (defaults to the app name)
 MAX_MEMORY_MIB=256 # threshold in MiB
 
+# Distinguish "deployment not found" from "request not set" so the message
+# points at the real cause instead of always blaming a missing deployment.
+if ! kubectl get deployment "$APP" -n "$NAMESPACE" >/dev/null 2>&1; then
+  echo "FAIL: deployment ${NAMESPACE}/${APP} not found — deploy it first (labctl app deploy ${APP})." >&2
+  exit 1
+fi
+
+# Read the named container's memory request (works for multi-container pods),
+# falling back to the first container if no container matches CONTAINER.
 raw=$(kubectl get deployment "$APP" -n "$NAMESPACE" \
-  -o jsonpath='{.spec.template.spec.containers[0].resources.requests.memory}' \
+  -o jsonpath="{.spec.template.spec.containers[?(@.name==\"$CONTAINER\")].resources.requests.memory}" \
   2>/dev/null || true)
+if [ -z "$raw" ]; then
+  raw=$(kubectl get deployment "$APP" -n "$NAMESPACE" \
+    -o jsonpath='{.spec.template.spec.containers[0].resources.requests.memory}' \
+    2>/dev/null || true)
+fi
 
 if [ -z "$raw" ]; then
-  echo "FAIL: could not read memory request from ${NAMESPACE}/${APP}. Is the deployment running?" >&2
+  echo "FAIL: no memory request set on ${NAMESPACE}/${APP} (container '${CONTAINER}')." >&2
+  echo "A missing request means the pod is scheduled with no memory reservation — set one to right-size:" >&2
+  echo "  kubectl -n ${NAMESPACE} set resources deployment ${APP} --requests=cpu=50m,memory=32Mi" >&2
   exit 1
 fi
 

--- a/scenarios/cost-right-sizing/scripts/inflate.sh
+++ b/scenarios/cost-right-sizing/scripts/inflate.sh
@@ -1,31 +1,41 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Re-deploy go-api with deliberately over-provisioned CPU/memory requests — the
-# 'before' state to observe in OpenCost. We UPGRADE the existing `go-api` Helm
-# release in place rather than creating a second release: `labctl app deploy
-# go-api` already owns a `go-api` release (and the `go-api` Deployment) in the
-# go-api namespace, so a separate release trying to adopt the same namespace and
-# Deployment fails helm's ownership validation. Reusing the release converges
-# cleanly and matches the scenario's story ("re-deploy go-api over-provisioned").
+# inflate.sh — put go-api into the deliberately over-provisioned 'before' state
+# (40x CPU / 32x memory) so the waste is visible in OpenCost before you right-size.
+#
+# We mutate the running Deployment in place with `kubectl set resources` — the
+# exact inverse of the fix the learner performs (`kubectl set resources ...
+# --requests=cpu=50m,memory=32Mi`). This is deliberately symmetric and robust:
+# it works regardless of how go-api was deployed (helm release, `kubectl apply`,
+# or the kind-e2e bootstrap) and regardless of which field-manager owns the
+# resource fields. An earlier `helm upgrade` approach failed with server-side
+# apply conflicts ("conflicts with kubectl") whenever go-api was not owned by
+# helm — `kubectl set resources` sidesteps that entirely.
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SCENARIO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-PROJECT_ROOT="$(cd "$SCENARIO_DIR/../.." && pwd)"
-CHART="$PROJECT_ROOT/apps/go-api/deploy/helm"
-VALUES="$SCENARIO_DIR/values/overprovisioned.yaml"
+NAMESPACE="${NAMESPACE:-go-api}"
+APP="${APP:-go-api}"
 
-echo "Re-deploying go-api over-provisioned (helm release: go-api)..."
-# Match the canonical app deploy (src/engine/deploy/helm.sh): create the namespace
-# out-of-band and pass namespace.create=false, so the chart doesn't render a
-# Namespace object helm cannot adopt (the go-api namespace already exists,
-# created by kubectl rather than helm).
-kubectl create namespace go-api --dry-run=client -o yaml | kubectl apply -f - >/dev/null 2>&1 || true
-helm upgrade --install go-api "$CHART" \
-  --namespace go-api --create-namespace \
-  --set namespace.create=false \
-  -f "$VALUES" \
-  --wait --timeout 5m
+# The inflated 'before' values. Requests drive scheduling and node billing;
+# limits are matched to requests here so the pod is a single fat, wasteful slot.
+CPU_REQUEST="${CPU_REQUEST:-2000m}"
+MEM_REQUEST="${MEM_REQUEST:-1Gi}"
+CPU_LIMIT="${CPU_LIMIT:-2000m}"
+MEM_LIMIT="${MEM_LIMIT:-1Gi}"
 
-echo "Done. go-api now requests 2000m CPU / 1Gi memory (the inflated baseline)."
-echo "Observe the cost in OpenCost, then right-size with 'kubectl -n go-api set resources'."
+if ! kubectl get deployment "$APP" -n "$NAMESPACE" >/dev/null 2>&1; then
+  echo "ERROR: deployment ${NAMESPACE}/${APP} not found." >&2
+  echo "Deploy it first: labctl app deploy ${APP}" >&2
+  exit 1
+fi
+
+echo "Over-provisioning ${NAMESPACE}/${APP}: requests cpu=${CPU_REQUEST}, memory=${MEM_REQUEST} (limits ${CPU_LIMIT}/${MEM_LIMIT})..."
+kubectl -n "$NAMESPACE" set resources deployment "$APP" \
+  --requests="cpu=${CPU_REQUEST},memory=${MEM_REQUEST}" \
+  --limits="cpu=${CPU_LIMIT},memory=${MEM_LIMIT}"
+
+echo "Waiting for the over-provisioned pod to roll out..."
+kubectl -n "$NAMESPACE" rollout status deployment "$APP" --timeout=5m
+
+echo "Done. ${APP} now requests ${CPU_REQUEST} CPU / ${MEM_REQUEST} memory (the inflated baseline)."
+echo "Observe the cost in OpenCost, then right-size with 'kubectl -n ${NAMESPACE} set resources'."

--- a/scenarios/cost-right-sizing/values/overprovisioned.yaml
+++ b/scenarios/cost-right-sizing/values/overprovisioned.yaml
@@ -1,6 +1,7 @@
 # Deliberately over-provisioned resource requests for the cost-right-sizing scenario.
-# These values represent the 'before' state: 80x the CPU and 32x the memory
-# that go-api actually needs at idle. In a real cluster this wastes node capacity
+# These values represent the 'before' state: 40x the CPU and 32x the memory
+# that go-api actually needs at idle (2000m vs the 50m baseline; 1Gi vs 32Mi).
+# In a real cluster this wastes node capacity
 # and inflates the per-namespace cost visible in OpenCost.
 #
 # The exercise: observe the inflated cost in OpenCost, then right-size the

--- a/src/internal/cli/content_display.go
+++ b/src/internal/cli/content_display.go
@@ -31,22 +31,30 @@ func renderReferences(w io.Writer, refs []scenario.Reference) {
 	}
 }
 
-// renderSnippets writes each applyable manifest snippet with its resolved body,
-// ready to copy into `kubectl apply -f -`. Path snippets are read from dir;
-// every body is template-resolved so it is applyable as printed. A snippet whose
-// file cannot be read is reported inline rather than silently dropped (the
-// loader already fails validation on a missing path, so this is belt-and-braces).
+// renderSnippets writes each reference snippet with its resolved body. Path
+// snippets are read from dir; every body is template-resolved so it prints as it
+// is used. Each snippet carries its own "apply with" hint (defaulting to
+// `kubectl apply -f -`) because not every snippet is a kubectl manifest — a Helm
+// values file, for instance, is applied differently, and labelling it as
+// kubectl-appliable would mislead the learner. A snippet whose file cannot be
+// read is reported inline rather than silently dropped (the loader already fails
+// validation on a missing path, so this is belt-and-braces).
 func renderSnippets(w io.Writer, snips []scenario.Snippet, dir string, resolve resolveFunc) {
 	if len(snips) == 0 {
 		return
 	}
-	fmt.Fprintf(w, "\nSnippets (apply with: kubectl apply -f -):\n")
+	fmt.Fprintf(w, "\nSnippets:\n")
 	for _, s := range snips {
+		apply := s.Apply
+		if apply == "" {
+			apply = "kubectl apply -f -"
+		}
 		fmt.Fprintf(w, "\n  # %s", s.Label)
 		if s.Description != "" {
 			fmt.Fprintf(w, " — %s", s.Description)
 		}
 		fmt.Fprintln(w)
+		fmt.Fprintf(w, "  # apply with: %s\n", apply)
 		body, err := snippetBody(s, dir, resolve)
 		if err != nil {
 			fmt.Fprintf(w, "    (unavailable: %v)\n", err)

--- a/src/internal/cli/content_display_test.go
+++ b/src/internal/cli/content_display_test.go
@@ -45,14 +45,23 @@ func TestRenderSnippets_InlineAndPathWithTemplate(t *testing.T) {
 	renderSnippets(&buf, []scenario.Snippet{
 		{Label: "inline", Description: "a note", YAML: "kind: ConfigMap"},
 		{Label: "from file", Path: "so.yaml"},
+		{Label: "helm values", YAML: "resources: {}", Apply: "helm upgrade -f -"},
 	}, dir, upper)
 	got := buf.String()
 
-	if !strings.Contains(got, "Snippets (apply with: kubectl apply -f -):") {
+	if !strings.Contains(got, "Snippets:") {
 		t.Errorf("missing snippets header: %q", got)
 	}
 	if !strings.Contains(got, "# inline — a note") {
 		t.Errorf("inline label/description missing: %q", got)
+	}
+	// A snippet with no Apply hint defaults to the kubectl-apply instruction.
+	if !strings.Contains(got, "# apply with: kubectl apply -f -") {
+		t.Errorf("default apply hint missing: %q", got)
+	}
+	// A snippet with an explicit Apply hint uses it instead of the default.
+	if !strings.Contains(got, "# apply with: helm upgrade -f -") {
+		t.Errorf("custom apply hint missing: %q", got)
 	}
 	if !strings.Contains(got, "    kind: ConfigMap") {
 		t.Errorf("inline body not indented: %q", got)

--- a/src/internal/cli/hosts.go
+++ b/src/internal/cli/hosts.go
@@ -26,6 +26,7 @@ var knownSubdomains = []string{
 	"echo-server",
 	"grafana",
 	"prometheus",
+	"opencost", // cost-right-sizing: OpenCost UI ingress
 	"argocd",
 	"traefik",
 	"kubernetes-dashboard",

--- a/src/internal/cli/hosts_test.go
+++ b/src/internal/cli/hosts_test.go
@@ -9,6 +9,20 @@ import (
 	"testing"
 )
 
+func TestBuildHostList_IncludesOpenCost(t *testing.T) {
+	hosts := buildHostList("k3d.local")
+	found := false
+	for _, h := range hosts {
+		if h == "opencost.k3d.local" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("buildHostList missing opencost.k3d.local (needed for the OpenCost UI ingress); got %v", hosts)
+	}
+}
+
 func TestComputeHostsContent(t *testing.T) {
 	block := buildBlock([]string{"grafana.k3d.local", "argocd.k3d.local"})
 

--- a/src/internal/cli/prereqs.go
+++ b/src/internal/cli/prereqs.go
@@ -5,10 +5,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/sagar2395/snowopslabs/internal/config"
 	"github.com/sagar2395/snowopslabs/internal/k8s"
+	"github.com/sagar2395/snowopslabs/internal/platform"
 )
 
 // appNamespace returns the namespace an app deploys into: its app.env NAMESPACE,
@@ -77,4 +79,85 @@ func ensureAppsDeployed(ctx context.Context, apps []string, autoDeploy bool) err
 			strings.Join(unknown, ", "))
 	}
 	return errors.New(strings.TrimRight(b.String(), "\n"))
+}
+
+// warnMissingPlatformPrereqs prints a non-fatal heads-up for each declared
+// platform prerequisite (e.g. "cost/opencost", "monitoring/metrics", "ingress")
+// that does not appear to be installed, naming the exact command to install it.
+//
+// Unlike app prerequisites, platform components are never auto-installed by
+// `scenario up`, and a missing one (say OpenCost for a cost scenario) otherwise
+// only surfaces as a cryptic check failure much later. This is intentionally a
+// warning, not a hard error: detection is best-effort (namespace existence), so
+// we must never wrongly block a correctly-provisioned cluster. Writes to w so
+// callers/tests can capture it; a nil or empty prereq list is a no-op.
+func warnMissingPlatformPrereqs(ctx context.Context, w io.Writer, prereqs []string) {
+	if len(prereqs) == 0 {
+		return
+	}
+	reg := platform.NewRegistry(cfg.ProjectRoot)
+
+	var missing []string
+	for _, pre := range prereqs {
+		namespaces := prereqNamespaces(reg, pre)
+		if len(namespaces) == 0 {
+			// Can't resolve this prereq to a namespace — don't guess, don't warn.
+			continue
+		}
+		present := false
+		for _, ns := range namespaces {
+			if k8s.NamespaceExists(ctx, ns) {
+				present = true
+				break
+			}
+		}
+		if !present {
+			missing = append(missing, pre)
+		}
+	}
+	if len(missing) == 0 {
+		return
+	}
+
+	fmt.Fprintf(w, "Warning: platform prerequisite(s) not detected: %s\n", strings.Join(missing, ", "))
+	fmt.Fprintln(w, "Some checks will fail until they are installed. Install them with:")
+	for _, pre := range missing {
+		fmt.Fprintf(w, "  labctl platform up %s\n", pre)
+	}
+}
+
+// prereqNamespaces resolves a platform-prerequisite string to the namespace(s)
+// whose existence signals it is installed. A prereq is one of:
+//   - a (sub)category with providers under it (e.g. "monitoring/metrics") → the
+//     namespace each of its providers installs into;
+//   - a category/provider pair (e.g. "cost/opencost") → that provider's namespace;
+//   - a bare category with providers (e.g. "ingress") → each provider's namespace
+//     (any one present counts, since ingress providers are mutually exclusive).
+//
+// Returns nil when the prereq cannot be resolved against the registry, so the
+// caller can skip it rather than emit a misleading warning.
+func prereqNamespaces(reg *platform.Registry, pre string) []string {
+	if provs := reg.GetProviders(pre); len(provs) > 0 {
+		return providerNamespaces(provs)
+	}
+	if i := strings.LastIndex(pre, "/"); i >= 0 {
+		if p, err := reg.GetProvider(pre[:i], pre[i+1:]); err == nil {
+			return []string{p.Namespace()}
+		}
+	}
+	return nil
+}
+
+// providerNamespaces returns the deduplicated namespaces of the given providers.
+func providerNamespaces(provs []platform.Provider) []string {
+	seen := map[string]bool{}
+	var out []string
+	for i := range provs {
+		ns := provs[i].Namespace()
+		if ns != "" && !seen[ns] {
+			seen[ns] = true
+			out = append(out, ns)
+		}
+	}
+	return out
 }

--- a/src/internal/cli/prereqs_test.go
+++ b/src/internal/cli/prereqs_test.go
@@ -4,42 +4,56 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"sort"
 	"testing"
 
-	"github.com/sagar2395/snowopslabs/internal/config"
+	"github.com/sagar2395/snowopslabs/internal/platform"
 )
 
-func writeApp(t *testing.T, root, name, appEnv string) {
+// writeProvider creates platform/<relDir>/install.sh so the registry scan
+// discovers a provider at that path.
+func writeProvider(t *testing.T, root, relDir string) {
 	t.Helper()
-	dir := filepath.Join(root, "apps", name)
+	dir := filepath.Join(root, "platform", relDir)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "app.env"), []byte(appEnv), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "install.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 }
 
-func TestAppExistsAndNamespace(t *testing.T) {
+func TestPrereqNamespaces(t *testing.T) {
 	root := t.TempDir()
-	writeApp(t, root, "with-ns", "APP_NAME=with-ns\nNAMESPACE=custom-ns\n")
-	writeApp(t, root, "no-ns", "APP_NAME=no-ns\n")
+	writeProvider(t, root, "cost/opencost")                 // category/provider
+	writeProvider(t, root, "monitoring/metrics/prometheus") // sub-category with a provider
+	writeProvider(t, root, "ingress/traefik")               // bare category, provider owns its ns
+	writeProvider(t, root, "ingress/nginx")                 // second mutually-exclusive provider
+	reg := platform.NewRegistry(root)
 
-	saved := cfg
-	cfg = &config.Config{ProjectRoot: root}
-	t.Cleanup(func() { cfg = saved })
-
-	if !appExists("with-ns") {
-		t.Error("appExists(with-ns) = false, want true")
+	tests := []struct {
+		name   string
+		prereq string
+		want   []string
+	}{
+		{"category/provider resolves to provider namespace", "cost/opencost", []string{"opencost"}},
+		{"sub-category resolves to shared monitoring namespace", "monitoring/metrics", []string{"monitoring"}},
+		{"bare category resolves to every provider namespace", "ingress", []string{"nginx", "traefik"}},
+		{"unknown prereq resolves to nothing", "does/not/exist", nil},
 	}
-	if appExists("nope") {
-		t.Error("appExists(nope) = true, want false")
-	}
-	// Explicit NAMESPACE wins; otherwise the app name is the namespace.
-	if got := appNamespace("with-ns"); got != "custom-ns" {
-		t.Errorf("appNamespace(with-ns) = %q, want %q", got, "custom-ns")
-	}
-	if got := appNamespace("no-ns"); got != "no-ns" {
-		t.Errorf("appNamespace(no-ns) = %q, want %q", got, "no-ns")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := prereqNamespaces(reg, tc.prereq)
+			sort.Strings(got)
+			sort.Strings(tc.want)
+			if len(got) != len(tc.want) {
+				t.Fatalf("prereqNamespaces(%q) = %v, want %v", tc.prereq, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("prereqNamespaces(%q) = %v, want %v", tc.prereq, got, tc.want)
+				}
+			}
+		})
 	}
 }

--- a/src/internal/cli/scenario.go
+++ b/src/internal/cli/scenario.go
@@ -99,6 +99,10 @@ var scenarioUpCmd = &cobra.Command{
 		if err := ensureAppsDeployed(cmd.Context(), s.Prerequisites.Apps, scenarioDeployPrereqs); err != nil {
 			return err
 		}
+		// Platform prerequisites (opencost, prometheus, ingress, …) are not
+		// auto-installed; warn up front if any is missing so a later check
+		// failure isn't the first the learner hears of it.
+		warnMissingPlatformPrereqs(cmd.Context(), os.Stderr, s.Prerequisites.Platform)
 		// An already-active scenario is a friendly no-op unless --force (which
 		// re-installs; components are idempotent).
 		if s.Active && !scenarioUpForce {
@@ -142,13 +146,31 @@ in seconds rather than minutes.`,
 }
 
 var scenarioStatusCmd = &cobra.Command{
-	Use:   "status",
+	Use:   "status [scenario-name]",
 	Short: "Show scenario status",
+	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		statuses := scenes.Status()
 		if len(statuses) == 0 {
 			fmt.Println("No scenarios found.")
 			return nil
+		}
+
+		// With a name argument, report just that scenario's status instead of
+		// listing every active one — matching what `status <name>` implies.
+		if len(args) == 1 {
+			name := args[0]
+			for _, s := range statuses {
+				if s.Name == name {
+					state := "inactive"
+					if s.Active {
+						state = "active"
+					}
+					fmt.Printf("%s (%s): %s\n", s.Name, s.Category, state)
+					return nil
+				}
+			}
+			return fmt.Errorf("scenario %q not found (see 'labctl scenario list')", name)
 		}
 
 		hasActive := false
@@ -213,22 +235,31 @@ With --watch, checks are re-run every --interval until they all pass or
 				recordScenarioVerify(args[0], results, startedAt)
 				return nil
 			}
-			failed := 0
+			// Separate genuine failures from checks that are merely pending the
+			// user's next drill step, so "you haven't run backup yet" never reads
+			// as "the scenario is broken".
+			var failed, pending int
 			for _, r := range results {
-				if !r.Pass {
+				switch {
+				case r.Pass:
+				case r.Pending:
+					pending++
+				default:
 					failed++
 				}
 			}
 			if !verifyWatch || time.Now().After(deadline) {
-				if !verifyWatch {
-					fmt.Fprintln(os.Stderr, "\nChecks can fail while pods are still starting. Re-run with --watch to wait,")
-					fmt.Fprintln(os.Stderr, "or inspect with: kubectl get pods -A")
-				}
+				printVerifyRemediation(results)
 				recordScenarioVerify(args[0], results, startedAt)
+				if failed == 0 && pending > 0 {
+					// Nothing regressed — the scenario just isn't finished. Report
+					// it as an incomplete drill, not a failure.
+					return fmt.Errorf("%d step(s) still pending — complete the drill above, then re-verify", pending)
+				}
 				return fmt.Errorf("%d of %d checks failed", failed, len(results))
 			}
-			fmt.Printf("\n%d of %d checks failing — retrying in %s (until %s)...\n\n",
-				failed, len(results), verifyInterval, deadline.Format("15:04:05"))
+			fmt.Printf("\n%d of %d checks not yet passing — retrying in %s (until %s)...\n\n",
+				failed+pending, len(results), verifyInterval, deadline.Format("15:04:05"))
 			time.Sleep(verifyInterval)
 		}
 	},
@@ -285,7 +316,14 @@ func printCheckResults(results []checks.Result) {
 	for _, r := range results {
 		mark := "PASS"
 		if !r.Pass {
-			mark = "FAIL"
+			// A check declared pending is expected to be red until the user
+			// performs the matching drill step — render it as PENDING, not a
+			// hard FAIL, so it doesn't read as breakage.
+			if r.Pending {
+				mark = "PENDING"
+			} else {
+				mark = "FAIL"
+			}
 		}
 		detail := ""
 		if r.Got != "" || r.Want != "" {
@@ -304,6 +342,40 @@ func orDash(s string) string {
 		return "-"
 	}
 	return s
+}
+
+// printVerifyRemediation prints targeted next-step guidance for the checks that
+// did not pass, instead of the old blanket "pods may still be starting" line
+// that misdirected troubleshooting whenever the real fix was an action (take a
+// backup, restore the marker). Each failing check with a declared Remediation
+// gets its own line; the generic pods/--watch hint is printed only when a check
+// failed with no remediation of its own — the case where waiting might actually
+// help (a rollout still settling).
+func printVerifyRemediation(results []checks.Result) {
+	var steps []string
+	genericFailure := false
+	for _, r := range results {
+		if r.Pass {
+			continue
+		}
+		if r.Remediation != "" {
+			steps = append(steps, fmt.Sprintf("  → %s: %s", r.Name, r.Remediation))
+			continue
+		}
+		if !r.Pending {
+			genericFailure = true
+		}
+	}
+	if len(steps) > 0 {
+		fmt.Fprintln(os.Stderr, "\nNext step(s):")
+		for _, s := range steps {
+			fmt.Fprintln(os.Stderr, s)
+		}
+	}
+	if genericFailure {
+		fmt.Fprintln(os.Stderr, "\nA check with no fix-it hint failed — a pod may still be starting.")
+		fmt.Fprintln(os.Stderr, "Re-run with --watch to wait, or inspect with: kubectl get pods -A")
+	}
 }
 
 var scenarioInfoCmd = &cobra.Command{
@@ -383,10 +455,10 @@ var scenarioInfoCmd = &cobra.Command{
 		if len(s.Explore.URLs) > 0 || len(s.Explore.Commands) > 0 || len(s.Explore.Tips) > 0 {
 			fmt.Println("\nExplore:")
 			for _, u := range s.Explore.URLs {
-				fmt.Printf("  URL: %-25s %s\n", u.Label, scenes.ResolveTemplate(u.URL))
+				fmt.Printf("  URL: %-25s %s\n", scenes.ResolveTemplate(u.Label), scenes.ResolveTemplate(u.URL))
 			}
 			for _, c := range s.Explore.Commands {
-				fmt.Printf("  CMD: %s\n       %s\n", c.Label, scenes.ResolveTemplate(c.Command))
+				fmt.Printf("  CMD: %s\n       %s\n", scenes.ResolveTemplate(c.Label), scenes.ResolveTemplate(c.Command))
 			}
 			for _, t := range s.Explore.Tips {
 				fmt.Printf("  TIP: %s\n", scenes.ResolveTemplate(t))

--- a/src/pkg/checks/checks.go
+++ b/src/pkg/checks/checks.go
@@ -53,6 +53,21 @@ type Check struct {
 
 	// TimeoutSeconds overrides the runner's default per-check timeout.
 	TimeoutSeconds int `yaml:"timeoutSeconds,omitempty" json:"timeoutSeconds,omitempty"`
+
+	// Remediation is a one-line, human-readable hint telling the user how to
+	// make a failing check pass (e.g. "take a backup first: …"). Advisory only:
+	// it never affects pass/fail, but verify surfaces it under the failing check
+	// instead of a generic "pods may still be starting" guess, so troubleshooting
+	// points at the real next step.
+	Remediation string `yaml:"remediation,omitempty" json:"remediation,omitempty"`
+
+	// Pending marks a check that is expected to be red until the user performs a
+	// drill step (take the backup, restore the marker). When such a check fails,
+	// verify renders it PENDING rather than a hard FAIL and reports it as an
+	// incomplete step, so "you haven't done the drill yet" never reads as "the
+	// scenario is broken". Advisory only: a pending check that fails still keeps
+	// the scenario short of "all checks passed".
+	Pending bool `yaml:"pending,omitempty" json:"pending,omitempty"`
 }
 
 // fieldOwners maps each type-specific field to the check types allowed to set
@@ -194,6 +209,13 @@ type Result struct {
 	// passes or a deadline elapses.
 	Attempts   int   `json:"attempts,omitempty"`
 	DurationMS int64 `json:"durationMs"`
+
+	// Remediation and Pending are copied from the originating Check so every
+	// consumer (CLI verify, HTTP API, UI) can render the right next step and
+	// distinguish "pending your action" from a genuine regression without
+	// re-reading the scenario definition.
+	Remediation string `json:"remediation,omitempty"`
+	Pending     bool   `json:"pending,omitempty"`
 }
 
 // explain composes a single human-readable sentence describing the outcome,

--- a/src/pkg/checks/runner.go
+++ b/src/pkg/checks/runner.go
@@ -105,6 +105,10 @@ func (r *Runner) Run(ctx context.Context, c Check) Result {
 	if res.Attempts == 0 {
 		res.Attempts = 1
 	}
+	// Advisory metadata travels with the result so the CLI, API and UI can all
+	// render the right next step without re-reading the scenario definition.
+	res.Remediation = c.Remediation
+	res.Pending = c.Pending
 	res.Explanation = res.explain()
 	res.DurationMS = time.Since(start).Milliseconds()
 	return res

--- a/src/pkg/checks/runner_test.go
+++ b/src/pkg/checks/runner_test.go
@@ -311,3 +311,26 @@ func TestRun_TimeoutRespected(t *testing.T) {
 		t.Fatalf("check ran past its timeout: %v", time.Since(start))
 	}
 }
+
+// TestRun_CarriesAdvisoryMetadata verifies a check's Remediation and Pending
+// fields travel through to the Result, so the CLI/API/UI can render the right
+// next step and distinguish "pending your action" from a genuine regression.
+func TestRun_CarriesAdvisoryMetadata(t *testing.T) {
+	r := testRunner()
+	r.Exec = func(ctx context.Context, name string, args ...string) (string, error) {
+		return "", fmt.Errorf("kubectl: not found")
+	}
+	res := r.Run(context.Background(), Check{
+		Name: "restore-marker-present", Type: "kubectl", Resource: "configmap/restore-marker",
+		Namespace: "go-api", Pending: true, Remediation: "restore from the backup",
+	})
+	if res.Pass {
+		t.Fatalf("expected fail")
+	}
+	if !res.Pending {
+		t.Fatalf("expected Pending to propagate to the result")
+	}
+	if res.Remediation != "restore from the backup" {
+		t.Fatalf("expected Remediation to propagate, got %q", res.Remediation)
+	}
+}

--- a/src/pkg/scenario/schema.go
+++ b/src/pkg/scenario/schema.go
@@ -152,15 +152,20 @@ type Reference struct {
 	Note  string `yaml:"note,omitempty" json:"note,omitempty"`
 }
 
-// Snippet is an applyable manifest fragment presented to the learner. Exactly
-// one of YAML (inline manifest text) or Path (a manifest file relative to the
-// item's directory) is set; both are template-resolved before display so a
-// snippet is applyable as-is. Reused by scenarios and incidents (M2).
+// Snippet is a reference fragment presented to the learner. Exactly one of YAML
+// (inline text) or Path (a file relative to the item's directory) is set; both
+// are template-resolved before display. Most snippets are kubectl manifests, but
+// some are other formats (e.g. Helm values) — set Apply to override the default
+// "kubectl apply -f -" hint with how this particular snippet is actually used.
+// Reused by scenarios and incidents (M2).
 type Snippet struct {
 	Label       string `yaml:"label" json:"label"`
 	Description string `yaml:"description,omitempty" json:"description,omitempty"`
 	YAML        string `yaml:"yaml,omitempty" json:"yaml,omitempty"`
 	Path        string `yaml:"path,omitempty" json:"path,omitempty"`
+	// Apply describes how to use the snippet. Empty means it is a kubectl
+	// manifest applied with "kubectl apply -f -" (the default hint).
+	Apply string `yaml:"apply,omitempty" json:"apply,omitempty"`
 }
 
 // Parameter is a user-tunable knob exposed at activation time. Its value is


### PR DESCRIPTION
## What

Fixes and hardens two scenarios — `backup-restore-drill` and `cost-right-sizing` — plus the CLI/checks plumbing they exposed gaps in.

**backup-restore-drill**
- Adds a stateful `data-writer` (Deployment + PVC, `manifests/stateful.yaml`) whose boot-id makes the manifest-vs-PV-data boundary observable: it survives a ConfigMap-delete restore but changes after a namespace-delete + restore, since the backup round-trips Kubernetes *objects*, not the *data* on a volume.
- `backup.sh` now also captures PVCs, scrubbing the volume binding (`spec.volumeName` + binder annotations) so a restore provisions a fresh volume instead of dangling on a deleted PV.
- `restore.sh` switches to server-side apply (`--server-side --force-conflicts`), so restores are quiet (no `last-applied-configuration` warnings) and idempotent; prints an object-count summary.
- `check-backup-exists.sh` reports object count + backup age instead of a bare "OK".
- New `observe-pv-data.sh` + an updated `explore` walkthrough (backup → delete configmap → verify pending → restore → verify → delete namespace → restore → observe boot-id change).
- New `pending` check state (`pkg/checks`, `internal/cli/scenario.go`) with a `Remediation` field: a check expected to be red until the learner performs a drill step now renders as `PENDING` with a targeted next-step hint instead of reading as scenario breakage.

**cost-right-sizing**
- `inflate.sh` now mutates the existing `go-api` Deployment in place with `kubectl set resources` instead of a `helm upgrade`, which broke with server-side-apply field conflicts whenever `go-api` wasn't helm-owned.
- OpenCost is reached via ingress (`http://opencost.{{.DomainSuffix}}`) with a `labctl hosts add` step and a port-forward fallback; the walkthrough drives real load via `labctl traffic start --profile steady` so usage is visible against requests in Grafana/OpenCost.

**CLI**
- `scenario status <name>` supports a single-scenario lookup.
- New `warnMissingPlatformPrereqs`: `scenario up` now warns up front when a declared platform prerequisite (e.g. `cost/opencost`) isn't installed, naming the install command, instead of surfacing only as a cryptic check failure later.

## Why

Part of #41. The manifest-vs-PV-data boundary was previously only described in prose (tips text) with nothing in the drill making it concrete — see #41 for the umbrella tracking issue and related follow-ups (#36-#40) that remain out of scope for this PR.

## How it was tested

- `go build ./...` and `go test ./internal/cli/... ./pkg/checks/... ./pkg/scenario/...` — all pass.
- Scenario YAML changes reviewed by inspection (not run against a live cluster in this environment).

## Type of change

- [x] Scenario / pack / content
- [x] Engine / CLI / SDK
- [ ] Platform module
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] Commits are signed off (`Signed-off-by` present)
- [ ] Conventional Commit title
- [x] Cross-platform & idempotent (no GNU-only shell flags; safe to re-run)
- [x] Updated relevant docs (`docs/cli-reference.md`, `docs/scenarios.md`)
- [ ] New source files carry an SPDX header
- [x] `go test ./...` passes locally (scoped to changed packages)


---
_Generated by [Claude Code](https://claude.ai/code/session_01MgH6aFXRx5kPXhfdqSf6nt)_