### PR TITLE
docs: track the authoring skills

### DIFF
--- a/.claude/skills/api-change/SKILL.md
+++ b/.claude/skills/api-change/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: api-change
+description: "Add or change a SnowOps Labs HTTP API route, middleware, error shape, pagination or auth rule, and keep the React client in step. Use whenever a task touches src/internal/httpapi/, src/ui/src/api/, an /api/v2 endpoint, or the run/job streaming."
+user-invocable: true
+---
+
+# Changing the API
+
+## Read first
+
+1. **[ADR-0006](../../../docs/adr/0006-api-conventions.md)** — the conventions
+   every route obeys.
+2. [docs/architecture/ARCHITECTURE.md §7](../../../docs/architecture/ARCHITECTURE.md)
+   — the API's place in the system and the real security posture.
+3. [docs/reference/cli/server.md](../../../docs/reference/cli/server.md) — what
+   users are told the server does.
+
+## The conventions
+
+Users are served **`/api/v2` only**. There is no other version.
+
+- **Errors are `application/problem+json`** with a stable `type` slug. Clients
+  branch on a constant, never on a message string.
+- **Mutations return `202` with a run ID.** Progress is streamed, not polled
+  blindly.
+- **Streaming is WebSocket with an SSE fallback**, both cursor-based.
+- **Collections paginate** with an opaque cursor and return `{items, nextCursor}`
+  plus an `ETag`; catalog reads honour `If-None-Match`.
+- **Every request carries a request ID**, echoed in the response and on every
+  log line.
+
+## Instrumentation is middleware, never per handler
+
+Metrics and access logging wrap the whole mux. Do **not** add a metrics call
+inside a handler — that is exactly how `/` ended up serving all the traffic
+unmeasured. A new route is measured because it is a route, not because someone
+remembered.
+
+Middleware order, outermost first: request ID → API version → access log →
+CORS → JSON → auth → metrics. Request ID and version are set before anything can
+reject the request, so even a CORS or auth failure gets a correlation ID and the
+right error envelope. Metrics sit innermost so they time the handler itself.
+
+## Adding a route
+
+1. Register it in `registerAPI` in `src/internal/httpapi/server.go`, with its
+   methods and `OPTIONS`.
+2. Put the handler in the file for its resource — `lab.go`, `incident.go`,
+   `challenge.go` and so on — not in `handlers.go` by default.
+3. Return collections through `respondCatalog` so pagination and ETags are
+   automatic. Return errors through `respondError` so the problem shape is.
+4. Long-running work goes through `internal/run`, and the route returns the run
+   ID. Never block a request on a shell-out.
+5. Update the React client in `src/ui/src/api/client.ts` and its MSW handlers in
+   `src/ui/src/test/server.ts`.
+
+## Auth
+
+The auth middleware is a pass-through when `LABCTL_AUTH` is off, so the local
+experience is unchanged. When on, it gates every route except the auth
+endpoints, and enforces operator-only mutations. A new mutating route is
+operator-only unless there is a stated reason it is not — say so in the PR.
+
+## Verify your work
+
+```bash
+make test-go                  # unit + contract tests, >=80% per package
+make test-ui                  # vitest, including the API client
+make lint
+```
+
+Tests are hermetic: `t.TempDir()`, `toolchain.Fake`, temp SQLite. Cover the
+happy path and at least two error cases, and for any `context.Context` argument
+add cancellation and deadline-exceeded tests.
+
+## Before you finish
+
+- [ ] Route registered once, under `/api/v2`.
+- [ ] Errors are problem+json; collections paginate and carry an ETag.
+- [ ] No per-handler metrics or logging.
+- [ ] Mutations return a run ID rather than blocking.
+- [ ] React client and MSW handlers updated.
+- [ ] Endpoint documented in the relevant
+      [CLI reference](../../../docs/reference/cli/index.md) page — every command
+      page lists its REST equivalents.
+- [ ] `make docs-check` passes.

--- a/.claude/skills/docs-sync/SKILL.md
+++ b/.claude/skills/docs-sync/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: docs-sync
+description: "Bring the documentation back in step with the code after any change, and keep the snowopslabs-web site building. Use at the END of every task that touched src/, scenarios/, incidents/, learn/, challenges/, platform/ or config/, and whenever a doc is added, renamed, split or deleted."
+user-invocable: true
+---
+
+# Keeping the docs true
+
+Documentation is the source of truth, and the website publishes these files
+directly. A change is not finished until the docs match it.
+
+## What to update, by what you changed
+
+| You changed | Update |
+|---|---|
+| A CLI command, flag or its help text | the matching page in `docs/reference/cli/` |
+| A `scenario.yaml` field or check type | `docs/reference/scenario-schema.md` |
+| A new or removed scenario | `docs/scenarios.md` (the catalog) |
+| A new or removed fault | the table in `incidents/README.md` |
+| A learning path or challenge | the table in `learn/README.md` or `challenges/README.md` |
+| A platform component or chart pin | `docs/runbooks/R05-platform-components.md` |
+| Anything metrics, logs or traces | `docs/runbooks/R13-observability-pipeline.md` |
+| An API route or convention | the REST section of the relevant `docs/reference/cli/` page |
+| A structural or notable decision | a new ADR under `docs/adr/`, listed in `docs/adr/README.md` |
+
+If the change makes an existing sentence false, fix that sentence. Stale docs
+are worse than missing ones, because agents are told to trust them.
+
+## Run the gates
+
+```bash
+make docs-check     # relative links resolve; every published path exists
+```
+
+`docs-links` also flags a documentation path cited in backticks that no longer
+exists — prose goes stale that way silently. ADRs are exempt, since they record
+files a decision deleted.
+
+## If you added, renamed, split or deleted a doc
+
+The website's manifest names each published file by path. A rename with no
+matching manifest edit drops the page from the site with no error.
+
+1. Edit `scripts/docs-manifest.mjs` in the **snowopslabs-web** repository —
+   `src` (path in this repo), `slug` (URL under `/docs`), `title`, `group`,
+   `desc`.
+2. Regenerate and verify there:
+   ```bash
+   npm run sync -- --local
+   npm run lint
+   npm run build
+   ```
+3. Commit the generated `content/` — it is committed, and the deployed site
+   keeps the old data until you do.
+4. Grep the site's own source for hardcoded links to the old slug:
+   `src/config/site.ts` and `src/app/` both carry some.
+
+`make docs-check` catches a missing manifest path from this side, but it cannot
+know about a hardcoded link in the site's components. Check both.
+
+## Writing style
+
+These pages are read by users of the product, not only by maintainers.
+
+- Lead with what the reader does, then the detail.
+- One idea per sentence; no wave, task or PR numbers anywhere.
+- Every command shown must run as written.
+- Mark anything not yet built as **Planned**. Never document an intention as if
+  it ships — especially a security property.
+
+## Before you finish
+
+- [ ] Every doc the change affects is updated in the same change.
+- [ ] `make docs-check` passes.
+- [ ] Manifest updated and the site rebuilt, if a doc moved.
+- [ ] No task or ticket numbers introduced.

--- a/.claude/skills/incident-author/SKILL.md
+++ b/.claude/skills/incident-author/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: incident-author
+description: "Write, edit, debug or review a SnowOps Labs incident (fault) — fault.yaml, inject.sh, resolve.sh, hints, solution, detection checks and paging drills. Use whenever a task involves anything under incidents/, a fault.yaml, `labctl incident inject|status|resolve`, or a fault that will not resolve cleanly."
+user-invocable: true
+---
+
+# Authoring an incident
+
+An incident is a **realistic, reversible** production fault. Inject it, let the
+lab break, diagnose it, fix it — and the detection check confirms the fix.
+
+## Read first
+
+1. **[incidents/README.md](../../../incidents/README.md)** — the fault contract:
+   every file a fault directory must contain, and the `fault.yaml` schema.
+2. [docs/reference/cli/incidents.md](../../../docs/reference/cli/incidents.md) —
+   the commands and how timing and history are recorded.
+3. The closest existing fault. `service-selector-broken` is the subtle one;
+   `oom-kill` is the one with a paging drill.
+
+Checks, references and snippets share the scenario shapes — see
+[the scenario schema](../../../docs/reference/scenario-schema.md).
+
+## The five rules
+
+1. **Target only the demo apps** (`go-api`, `echo-server`) or a dedicated fault
+   namespace. Never platform components, never `kube-system`.
+2. **Record what you change.** Annotate the touched resource with
+   `labfault-<name>=...` and stash originals in `labfault-<name>-original-*`, so
+   `resolve.sh` can undo it without guessing.
+3. **`resolve.sh` must never fail the user.** It runs after any amount of manual
+   fixing. Every step tolerates "already fixed" — `--ignore-not-found`, guards,
+   `|| true` where it is genuinely safe.
+4. **`inject.sh` is idempotent.** Re-running while injected is a no-op.
+5. **Write the detection check as "what must be true when healthy."** It is both
+   the resolution detector and the challenge grader, so it has to be honest in
+   both directions: it must fail while the fault is live and pass once — and
+   only once — the user has really fixed it.
+
+Hints go from gentle nudge to near-answer. The last hint may name the resource;
+the solution names the command.
+
+## Paging drills
+
+A fault with `expectAlert` must ship `alerts/rule.yaml`: a PrometheusRule
+labelled `release: prometheus` so kube-prometheus-stack loads it, whose alert
+carries `labfault: "true"` so Alertmanager routes it to the pager.
+
+`inject.sh` arms it (tolerating a missing monitoring stack), `resolve.sh`
+disarms it, and `labctl incident status` reports whether the page fired by
+querying `ALERTMANAGER_URL`.
+
+## Verify your work
+
+```bash
+labctl validate
+labctl incident inject my-fault
+labctl incident status              # must FAIL while the fault is live
+# ...fix it by hand, the way a learner would...
+labctl incident status              # must PASS once genuinely fixed
+labctl incident resolve             # must restore the lab from any state
+```
+
+Then prove the escape hatch independently: inject, fix nothing, `resolve`, and
+confirm the lab is clean. Also inject, fix it *partly* by hand, then `resolve`
+— that is the path that breaks naive resolve scripts.
+
+## Before you finish
+
+- [ ] `fault.yaml`, `inject.sh`, `resolve.sh`, `hints.md`, `solution.md` all present.
+- [ ] `inject.sh` is idempotent; `resolve.sh` survives a partial manual fix.
+- [ ] Detection check fails while broken and passes when fixed.
+- [ ] Scripts are POSIX and pass `make lint-shell`.
+- [ ] `alerts/rule.yaml` present if `expectAlert` is set.
+- [ ] Listed in the fault table in [incidents/README.md](../../../incidents/README.md).
+- [ ] `make docs-check` passes.

--- a/.claude/skills/learning-author/SKILL.md
+++ b/.claude/skills/learning-author/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: learning-author
+description: "Write, edit, debug or review a SnowOps Labs learning path or challenge — path.yaml, modules, intros, completion checks, challenge.yaml, par times and grading. Use whenever a task involves anything under learn/ or challenges/, or `labctl learn|challenge`."
+user-invocable: true
+---
+
+# Authoring learning paths and challenges
+
+Both are thin wrappers over content that already exists. A path sequences
+scenarios, incidents and commands into modules; a challenge puts a clock and a
+grade on one of them. Neither should introduce new mechanics of its own.
+
+## Read first
+
+- **Paths:** [learn/README.md](../../../learn/README.md) — `path.yaml`, module
+  shape, `action.type` and `check.type`.
+- **Challenges:** [challenges/README.md](../../../challenges/README.md) —
+  `challenge.yaml` and the score formula.
+- Commands for both:
+  [docs/reference/cli/learning.md](../../../docs/reference/cli/learning.md).
+
+Checks use the same types as scenario checks — see
+[the scenario schema](../../../docs/reference/scenario-schema.md#checks).
+
+## Learning paths
+
+A module is one thing the learner does, plus one check proving they did it.
+
+```yaml
+modules:
+  - name: init-cluster                    # unique within the path
+    displayName: "Start the cluster"
+    intro: intros/01-init-cluster.md      # optional, but write one
+    action:
+      type: command                       # command | scenario | incident
+      ref: "labctl runtime up"
+    check:
+      name: cluster-reachable
+      type: script                        # http | script | promql
+      script: checks/cluster-reachable.sh
+      timeoutSeconds: 30
+```
+
+- `action.type: command` shows the `ref` verbatim for the learner to run.
+- `action.type: scenario` or `incident` points at content by name, which
+  `labctl validate` cross-checks — a dangling reference is an error.
+- The check must be **provable by the learner's own work**, not by the module
+  having been displayed. A check that passes before the learner does anything is
+  the most common defect here.
+
+Order modules so each one leaves the lab in the state the next one assumes.
+`labctl learn next` walks them in declaration order and will not skip ahead.
+
+## Challenges
+
+```yaml
+name: restore-broken-deploy
+parTime: "10m"                  # Go duration; omit for unscored time
+setup:
+  type: incident                # incident | scenario
+  ref: bad-deploy-rollout
+grading:
+  useDetectionCheck: true       # reuse the fault's own detection check
+hintPenalty: 5                  # % per hint (default 5)
+```
+
+Prefer `useDetectionCheck: true`. The fault's detection check is already
+written as "what must be true when healthy", which is exactly the grading
+question — a second, hand-written set of checks drifts from it.
+
+Set `parTime` from an actual timed run, not a guess. It drives the time
+deduction, so a wrong par time makes every score wrong:
+
+```
+final = (100 − hints×penalty − min(20, (elapsed−par)/par × 20)) × checks_passed/checks_total
+```
+
+## Verify your work
+
+```bash
+labctl validate                          # schema and cross-references
+labctl learn start my-path
+labctl learn next my-path                # must NOT pass before you do the work
+# ...do the module...
+labctl learn next my-path                # must pass and advance
+labctl learn progress my-path
+```
+
+```bash
+labctl challenge start my-challenge
+labctl challenge submit                  # score must reflect what you actually did
+labctl challenge abort                   # must undo the setup cleanly
+```
+
+## Before you finish
+
+- [ ] `labctl validate` is clean; every `ref` resolves.
+- [ ] Every check fails before the work and passes after.
+- [ ] Modules leave the lab in the state the next module assumes.
+- [ ] `parTime` came from a real timed run.
+- [ ] Listed in the table in the relevant README.
+- [ ] `make docs-check` passes.

--- a/.claude/skills/platform-component/SKILL.md
+++ b/.claude/skills/platform-component/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: platform-component
+description: "Add, upgrade, debug or remove a SnowOps Labs platform component — Helm charts, chart pinning, values ownership, CRDs, StatefulSet immutability and provider selection. Use whenever a task involves anything under platform/, config/versions.env, a helm install or upgrade, or a component that will not install, upgrade or uninstall cleanly."
+user-invocable: true
+---
+
+# Platform components
+
+A component lives at `platform/<category>/<component>/` and is installed by
+shell and helm, orchestrated by Go. Go never grows helm logic.
+
+## Read first
+
+1. **[docs/runbooks/R05-platform-components.md](../../../docs/runbooks/R05-platform-components.md)**
+   — how to add one, and every Helm trap this repo has hit.
+2. [ADR-0010](../../../docs/adr/0010-platform-values-single-source.md) — values
+   ownership. [ADR-0011](../../../docs/adr/0011-chart-pinning-and-repo-migration.md)
+   — chart pinning.
+3. [docs/reference/cli/platform.md](../../../docs/reference/cli/platform.md) —
+   the commands and how targets and providers resolve.
+
+Observability components additionally:
+[R13](../../../docs/runbooks/R13-observability-pipeline.md).
+
+## Adding one — all in the same change
+
+1. The component directory with **exactly one** `values.yaml`.
+2. A chart version pin in `config/versions.env`. There is no
+   `helm upgrade --install` without `--version`.
+3. Install and uninstall through `helm_upgrade_install` from
+   `platform/_lib/helm.sh`, never a raw `helm` call.
+4. A `status.sh` so `platform status --live` can report on it.
+5. Documentation: R05, and the component in the reference.
+
+## The traps
+
+**`helm upgrade` never updates CRDs.** `crds/` is install-only, so an operator
+chart's major bump leaves stale CRDs and a crash-looping operator. Apply the
+pinned chart's CRDs with `kubectl apply --server-side` first — but only when the
+release already exists, or Helm's own CRD install conflicts on `.spec.versions`.
+
+**`helm uninstall` never deletes CRDs either.** A component whose uninstall
+leaves cluster-scoped CRDs behind is not uninstalled, and the next install
+inherits a CRD whose `status.storedVersions` can block it outright.
+
+**Most of a StatefulSet spec is immutable.** `helm_upgrade_install` recovers by
+deleting the controller with `--cascade=orphan` — pods and PVCs survive — and
+retrying. Use it for anything StatefulSet-backed.
+
+**Values live in one place.** A scenario that needs your component points at
+your `values.yaml` with `platformValues:` and overlays only its differences. A
+second full copy drifts, and Helm turns the drift into an immutable-field error.
+
+**A scenario that adopts your release must not uninstall it.**
+
+## Observability components
+
+If the component emits metrics, logs or traces, read
+[R13](../../../docs/runbooks/R13-observability-pipeline.md) before wiring it up
+— every failure mode there is silent. In particular: label every
+ServiceMonitor, PodMonitor and PrometheusRule `release: prometheus`, and set the
+three `*SelectorNilUsesHelmValues: false` flags, because an empty selector does
+*not* mean "select everything".
+
+## Verify your work
+
+```bash
+labctl platform up <category>/<component>
+labctl platform status <category>/<component> --live
+labctl platform up <category>/<component>      # again — must be a clean no-op
+labctl platform down <category>/<component>
+labctl platform up <category>/<component>      # and reinstall cleanly
+```
+
+The second install is the one that catches immutable-field and stale-CRD
+failures. Do not skip it.
+
+## Before you finish
+
+- [ ] One `values.yaml`, no duplicates anywhere.
+- [ ] Chart version pinned in `config/versions.env`.
+- [ ] Uses `helm_upgrade_install`, not raw `helm`.
+- [ ] Install → reinstall → uninstall → reinstall is clean.
+- [ ] Uninstall leaves no cluster-scoped CRDs behind.
+- [ ] Scripts are POSIX and pass `make lint-shell`.
+- [ ] R05 updated; an ADR added if the decision is notable.
+- [ ] `make docs-check` passes.

--- a/.claude/skills/scenario-author/SKILL.md
+++ b/.claude/skills/scenario-author/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: scenario-author
+description: "Write, edit, debug or review a SnowOps Labs scenario — scenario.yaml, stages, components, checks, parameters, values ownership and chart pinning. Use whenever a task involves anything under scenarios/, a scenario.yaml, `labctl scenario up|verify|new`, or a scenario check that fails or passes when it should not."
+user-invocable: true
+---
+
+# Authoring a scenario
+
+## Read first, in this order
+
+1. **[docs/reference/scenario-schema.md](../../../docs/reference/scenario-schema.md)** — the
+   complete field reference. Trust it; do not read `src/pkg/scenario/schema.go`
+   to confirm a field exists.
+2. [docs/authoring/first-scenario.md](../../../docs/authoring/first-scenario.md)
+   — the walkthrough, if you are starting from nothing.
+3. An existing scenario closest to the one you are writing. `observability-sre`
+   is the richest example; `autoscaling-under-load` is the one with parameters.
+
+Read the engine (`src/internal/scenario/`) only if the schema doc cannot answer
+your question — and if that happens, fix the schema doc in the same change.
+
+## Start from the scaffold
+
+```bash
+labctl scenario new my-scenario     # valid and verify-green immediately
+```
+
+Never hand-write the directory. The scaffold gives you a passing readiness
+check, which is the shape every other check should follow.
+
+## The rules that bite
+
+**One values file per component.** A component's Helm values live once, at
+`platform/<category>/<component>/values.yaml`. Point at it with
+`platformValues:` and put only your differences in `valuesFile:`. Never copy the
+platform's values into the scenario — the copy drifts, and Helm reports the
+drift as a forbidden update to an immutable StatefulSet field (ADR-0010).
+
+**Every chart is pinned.** `version:` is required on every `helm` component, and
+the pin lives in `config/versions.env`. Adding a component means adding its pin
+in the same change (ADR-0011).
+
+**Adopt what the platform owns.** `adopt: true` reuses an installed release
+instead of upgrading it. A scenario that adopts a release must **not** uninstall
+it on teardown.
+
+**Undo your scripts.** A `script` component needs an `uninstallScript`, or its
+side effects outlive the scenario.
+
+**Use `labctl traffic`, never a curl loop.** It runs k6 in-cluster and
+remote-writes the client-side metrics that dashboards compare against the app's
+own counters.
+
+## Writing checks
+
+Checks are the grading primitive. Write them as "what must be true when this
+scenario is healthy", not "what did I just install".
+
+- Assert the **metric exists**, not just that the pod is running. An empty
+  dashboard should fail `verify` rather than quietly confuse a learner.
+- Give every check that a user can act on a `remediation`. It prints under
+  **Next step(s)** instead of the generic "a pod may still be starting" hint.
+- Mark a check `pending: true` when it represents a drill step the user has not
+  performed yet. It renders PENDING rather than FAIL, so "you have not run the
+  backup" does not read as "the scenario is broken".
+- Comparing a running image? Use `.spec.containers[].image`.
+  `.status.containerStatuses[].image` reports whichever tag the kubelet
+  resolved, so it says `:latest` for a pod that asked for `:v1.1.0` when the
+  tags share a digest.
+- Avoid tautologies. A check that asserts a file you just applied exists proves
+  nothing about the pipeline.
+
+## Verify your work
+
+```bash
+labctl validate                       # schema, cross-references, templates
+labctl scenario up my-scenario
+labctl scenario verify my-scenario    # every check must pass
+labctl scenario down my-scenario      # and tear down cleanly
+labctl scenario reset my-scenario     # fast retry, no lab teardown
+```
+
+A scenario is not done until `up → verify → down` is clean on a fresh cluster.
+Only then is `verified: true` honest — and that flag is curation metadata for
+the nightly e2e job, not a user-facing badge.
+
+## Before you finish
+
+- [ ] `labctl validate` is clean.
+- [ ] Every `helm` component has a `version`, pinned in `config/versions.env`.
+- [ ] No duplicated platform values; `platformValues:` used where applicable.
+- [ ] Every `script` component has an `uninstallScript`.
+- [ ] Checks assert the observable outcome, with `remediation` where useful.
+- [ ] Added to the catalog in [docs/scenarios.md](../../../docs/scenarios.md).
+- [ ] New or changed schema fields documented in
+      [the schema reference](../../../docs/reference/scenario-schema.md).
+- [ ] `make docs-check` passes.

--- a/.gitignore
+++ b/.gitignore
@@ -48,12 +48,12 @@ Thumbs.db
 .labctl/
 .snowops/
 
-## AI-assisted development scaffolding — kept locally, never part of the
-## public repository (planning state, session instructions, scratch logs).
+## Local session scaffolding — planning state, session instructions, scratch
+## logs. The authoring skills under .claude/skills/ are deliberately NOT here:
+## they route contributors to the public docs and are part of the open core.
 .ai/
 CLAUDE.md
 AGENTS.md
-.claude/skills/
 
 ## Internal migration planning — local only, never committed
 .roadmap/

--- a/docs/AGENT-CONTEXT.md
+++ b/docs/AGENT-CONTEXT.md
@@ -44,6 +44,15 @@ contradict themselves, or you are editing the code in question.
 
 Everything else: [docs/README index in the root README](../README.md#documentation).
 
+## Skills
+
+`.claude/skills/` holds packaged versions of the routes above, for harnesses
+that support them — `scenario-author`, `incident-author`, `learning-author`,
+`platform-component`, `api-change` and `docs-sync`. Each one names the documents
+to read, the rules that are easy to break, and a checklist to finish against.
+They are a shortcut to the docs, never a replacement: when a skill and a document
+disagree, the document wins and the skill is the bug.
+
 ---
 
 ## Invariants


### PR DESCRIPTION
## What

Tracks the six authoring skills under `.claude/skills/` instead of ignoring
them, and points at them from `docs/AGENT-CONTEXT.md`.

| Skill | Covers |
|---|---|
| `scenario-author` | `scenario.yaml`, stages, checks, parameters, values ownership, chart pinning |
| `incident-author` | the fault contract, idempotent inject, resolve that survives a partial manual fix |
| `learning-author` | learning paths and challenges — modules, completion checks, par times, grading |
| `platform-component` | adding a chart: the pin, the single values file, CRDs, StatefulSet immutability |
| `api-change` | route registration, problem+json, pagination, middleware-only instrumentation |
| `docs-sync` | what to update after a change, and the website manifest coupling |

Each one names the documents to read, lists the rules that are easy to break,
and ends in a checklist.

## Why

They were ignored on the theory that easier authoring erodes the value of paid
content. It does not: every document these skills point at — the schema
reference, the runbooks, the ADRs — is already public and published on the
site, and `labctl scenario new` already scaffolds a working scenario. They add
a routing layer and a checklist over material anyone can read today, so keeping
them private withheld nothing and taxed exactly the people most likely to
contribute content.

Follows the same reasoning as #48, which found operational knowledge stranded
in the gitignored `CLAUDE.md`. `CLAUDE.md`, `AGENTS.md` and `.ai/` stay ignored
— `docs/AGENT-CONTEXT.md` already carries their substance in tracked docs.

The `.gitignore` comment is rewritten to say the exclusion is deliberate, so the
directory is not swept back in by someone pattern-matching on "AI scaffolding".

## The precedence rule

`AGENT-CONTEXT.md` states it explicitly: the skills are a shortcut to the docs,
never a replacement. **When a skill and a document disagree, the document wins
and the skill is the bug.** Without that, this would create a second source of
truth alongside the one the previous PR just established.

## How it was tested

`make docs-check` passes, and now actually covers these files: the link checker
walks tracked `.md` files, so every `../../../docs/...` reference in a skill is
verified to resolve. A future doc rename can no longer break them silently —
which is the main risk of committing them at all.

No code changes; no other gate is affected.

## Type of change

- [x] Docs

## Checklist

- [x] My commits are signed off
- [x] Conventional Commit title
- [x] Cross-platform & idempotent
- [x] Updated relevant **docs** (`AGENT-CONTEXT.md`)
- [x] New source files carry an SPDX header — n/a, Markdown only
- [x] `go test ./...`, shellcheck, and yamllint pass locally
