### PR TITLE
fix(ci): make the kind e2e wait for rollouts and walk the promotion d…

### DIFF
--- a/.github/workflows/e2e-kind.yaml
+++ b/.github/workflows/e2e-kind.yaml
@@ -1,8 +1,8 @@
 # End-to-end test on kind — the real-cluster gate (docs/TESTING.md).
 #
 # kind is a headless, CI-friendly runtime, so we can run a real lab lifecycle in
-# GitHub Actions: create a cluster, load the app image, activate a scenario, and
-# assert its checks pass via `labctl scenario verify`.
+# GitHub Actions: create a cluster, load the app image, activate a scenario,
+# walk its drill, and assert its checks pass via `labctl scenario verify`.
 #
 # Scheduled nightly + manual only (never per-PR): an e2e run is heavier and
 # slower than the unit suite, and a flake should not block merges.
@@ -60,8 +60,52 @@ jobs:
         # before activating, so the run doesn't fail preflight.
         run: labctl scenario up env-promotion --deploy-prereqs
 
+      - name: Wait for the baseline rollout in every environment
+        # `scenario up` returns once the manifests are applied, not once the
+        # pods are ready, and the readiness checks read .status.readyReplicas.
+        # Without this the run grades the cluster a second or two after apply
+        # and fails on a race, not on a defect.
+        run: |
+          for env_name in dev staging prod; do
+            kubectl -n "env-${env_name}" rollout status deployment/go-api --timeout=180s
+          done
+
+      - name: Promote v1.1.0 through dev -> staging -> prod
+        # env-promotion's last check, newer-release-reached-prod, is declared
+        # `pending: true`: it only passes once a release newer than the v1.0.0
+        # baseline has reached prod, so `verify` on a freshly activated scenario
+        # can never exit 0. Walk the drill the way a learner does — that is what
+        # this job is actually here to prove works end to end: build a versioned
+        # image, load it into the cluster, roll it out per environment, and
+        # record the release in each env's ConfigMap.
+        run: |
+          bash scenarios/env-promotion/scripts/build-image.sh v1.1.0
+          promoted_from=""
+          for env_name in dev staging prod; do
+            ns="env-${env_name}"
+            kubectl -n "$ns" set image deployment/go-api go-api=go-api:v1.1.0
+            kubectl -n "$ns" rollout status deployment/go-api --timeout=180s
+            kubectl -n "$ns" patch cm env-metadata --type=merge -p "{\"data\":{\"declared_tag\":\"v1.1.0\",\"promoted_from\":\"${promoted_from}\",\"promoted_at\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}}"
+            promoted_from="$env_name"
+          done
+
       - name: Verify scenario checks pass
-        run: labctl scenario verify env-promotion
+        # --watch so the last of the superseded pods finishing termination reads
+        # as "not settled yet" rather than as a failed run:
+        # check-images-consistent.sh looks at every Running pod, and a pod that
+        # is terminating is still Phase=Running for a few seconds after
+        # `rollout status` returns.
+        run: labctl scenario verify env-promotion --watch --timeout=5m
+
+      - name: Dump cluster state on failure
+        if: failure()
+        run: |
+          kubectl get pods -A -o wide || true
+          for env_name in dev staging prod; do
+            ns="env-${env_name}"
+            kubectl -n "$ns" get deploy,rs,cm -o wide || true
+            kubectl -n "$ns" describe deployment go-api || true
+          done
 
       - name: Tear down scenario
         if: always()


### PR DESCRIPTION
The nightly e2e has failed on every run since env-promotion's newer-release-reached-prod check was marked `pending: true`. Two distinct defects:

1. `labctl scenario verify` ran roughly two seconds after `scenario up` applied the three environment manifests, so go-api-running-in-dev and go-api-running-in-prod read an empty .status.readyReplicas and failed on a race rather than a defect. The job now waits on `kubectl rollout status` for all three Deployments first.

2. newer-release-reached-prod only passes once a release newer than the v1.0.0 baseline has reached prod, so verify on a freshly activated scenario could never exit 0 — no amount of waiting would have made this job green. The job now walks the drill the scenario teaches: build go-api:v1.1.0, load it into kind, roll it out dev → staging → prod and record each release in env-metadata. That is a stricter e2e than before — it exercises build, image load, rollout and release recording — and it makes all eight checks legitimately pass.

Verify also runs with --watch now, so the few seconds a superseded pod spends terminating (still Phase=Running, which check-images-consistent.sh inspects) read as "not settled yet" instead of failing the run. A failure dump of pods, ReplicaSets and Deployment events was added so the next real break is diagnosable from the log alone.

<!-- Thanks for contributing to SnowOps Labs! Please fill this out. -->

## What

<!-- What does this PR do? One or two sentences. -->

## Why

<!-- The motivation / the issue it closes. Link issues: Closes #123 -->

## How it was tested

<!-- Commands you ran, cluster you tested on (k3d/AKS/EKS), scenario verify output, etc. -->

## Type of change

- [ ] Scenario / pack / content
- [ ] Platform module
- [x] Docs
- [ ] Engine / CLI / SDK (requires an RFC under `docs/rfcs/` — link it)
- [x] CI / tooling

## Checklist

- [x] My commits are signed off (`git commit -s` — see DCO.md)
- [ ] Conventional Commit title (`feat:`, `fix:`, `docs:`, `ci:`, `chore:`)
- [ ] Cross-platform & idempotent (no GNU-only shell flags; safe to re-run)
- [ ] Updated relevant **docs** and the **runbook** (golden rule 8)
- [ ] New source files carry an SPDX header (`// SPDX-License-Identifier: Apache-2.0`)
- [ ] `go test ./...`, shellcheck, and yamllint pass locally
